### PR TITLE
Fix a mono issue causing FileSystemWatcher events not to be fired.

### DIFF
--- a/Oxide.Core/Plugins/Watchers/FSWatcher.cs
+++ b/Oxide.Core/Plugins/Watchers/FSWatcher.cs
@@ -51,15 +51,13 @@ namespace Oxide.Core.Plugins.Watchers
         private void LoadWatcher(string directory, string filter)
         {
             // Create the watcher
-            watcher = new FileSystemWatcher(directory, filter)
-            {
-                IncludeSubdirectories = true,
-                NotifyFilter = NotifyFilters.LastWrite
-            };
+            watcher = new FileSystemWatcher(directory, filter);
             watcher.Changed += watcher_Changed;
             watcher.Created += watcher_Changed;
             watcher.Deleted += watcher_Changed;
             watcher.Error += watcher_Error;
+            watcher.NotifyFilter = NotifyFilters.LastWrite;
+            watcher.IncludeSubdirectories = true;
             watcher.EnableRaisingEvents = true;
             GC.KeepAlive(watcher);
         }

--- a/Oxide.Core/Plugins/Watchers/FSWatcher.cs
+++ b/Oxide.Core/Plugins/Watchers/FSWatcher.cs
@@ -53,7 +53,6 @@ namespace Oxide.Core.Plugins.Watchers
             // Create the watcher
             watcher = new FileSystemWatcher(directory, filter)
             {
-                EnableRaisingEvents = true,
                 IncludeSubdirectories = true,
                 NotifyFilter = NotifyFilters.LastWrite
             };
@@ -61,6 +60,7 @@ namespace Oxide.Core.Plugins.Watchers
             watcher.Created += watcher_Changed;
             watcher.Deleted += watcher_Changed;
             watcher.Error += watcher_Error;
+            watcher.EnableRaisingEvents = true;
             GC.KeepAlive(watcher);
         }
 


### PR DESCRIPTION
Apparently Mono refuses to fire events on Linux when setting "EnableRaisingEvents" before assigning the events, this fixes that.