### PR TITLE
Add GetFiles(string path) to Oxide.Core.Utility

### DIFF
--- a/Oxide.Core/Utility.cs
+++ b/Oxide.Core/Utility.cs
@@ -162,6 +162,15 @@ namespace Oxide.Core
             return value.Substring(firstIndex, (lastIndex - firstIndex + 1));
         }
 
+        public static string[] GetFileNames(string path)
+        {
+            if (!path.StartsWith(Core.Interface.Oxide.InstanceDirectory))
+            {
+                throw new Exception(string.Format("Only access to oxide directory!\nPath: {0}", path));
+            }
+            return System.IO.Directory.GetFiles(path);
+        }
+        
         public static string CleanPath(string path)
         {
             return path?.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);


### PR DESCRIPTION
Gives us an option to get all the file names in a certain directory, so we can spread out data files out. 

Would be very useful for existing plugins such as the copy paste plugin, so you could get a list of all structures in your data folder.