### PR TITLE
Modified Interface.CallHook() to use overloads instead of creating garbage

### DIFF
--- a/Oxide.Core/ArrayPool.cs
+++ b/Oxide.Core/ArrayPool.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Oxide.Core
 {
@@ -48,7 +47,6 @@ namespace Oxide.Core
             {
                 array[i] = null;
             }
-            if (_)
             _pooledArrays[array.Length].Enqueue(array);
         }
 

--- a/Oxide.Core/ArrayPool.cs
+++ b/Oxide.Core/ArrayPool.cs
@@ -47,11 +47,16 @@ namespace Oxide.Core
             {
                 array[i] = null;
             }
-            if (_pooledArrays[array.Length - 1].Count > MaxPoolAmount)
+            var arrays = _pooledArrays[array.Length - 1];
+            if (arrays.Count > MaxPoolAmount)
             {
+                for (int i = 0; i < InitialPoolAmount; i++)
+                {
+                    arrays.Dequeue();
+                }
                 return;
             }
-            _pooledArrays[array.Length - 1].Enqueue(array);
+            arrays.Enqueue(array);
         }
 
         private static void SetupArrays(int length)

--- a/Oxide.Core/ArrayPool.cs
+++ b/Oxide.Core/ArrayPool.cs
@@ -14,6 +14,15 @@ namespace Oxide.Core
 
         private static List<Queue<object[]>> _pooledArrays = new List<Queue<object[]>>();
 
+        static ArrayPool()
+        {
+            for(int i = 0; i < MaxArrayLength; i++)
+            {
+                _pooledArrays.Add(new Queue<object[]>());
+                SetupArrays(i + 1);
+            }
+        }
+
         public static object[] Get(int length)
         {
             if (length == 0 || length > MaxArrayLength)

--- a/Oxide.Core/ArrayPool.cs
+++ b/Oxide.Core/ArrayPool.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Oxide.Core
+{
+    public static class ArrayPool
+    {
+        private const int MaxArrayLength = 10;
+        private const int InitialPoolAmount = 64;
+        private const int MaxPoolAmount = 256;
+
+        private static List<Queue<object[]>> _pooledArrays = new List<Queue<object[]>>();
+
+        public static object[] Get(int length)
+        {
+            if (length == 0 || length > MaxArrayLength)
+            {
+                return new object[length];
+            }
+            var arrays = _pooledArrays[length - 1];
+            if (arrays.Count == 0)
+            {
+                SetupArrays(length);
+            }
+            return arrays.Dequeue();
+        }
+
+        public static void Free(object[] array)
+        {
+            if (array.Length == 0 || array.Length > MaxArrayLength)
+            {
+                return;
+            }
+            //Cleanup array
+            for(int i = 0; i < array.Length; i++)
+            {
+                array[i] = null;
+            }
+            if (_)
+            _pooledArrays[array.Length].Enqueue(array);
+        }
+
+        private static void SetupArrays(int length)
+        {
+            var arrays = _pooledArrays[length - 1];
+            for (int i = 0; i < InitialPoolAmount; i++)
+            {
+                arrays.Enqueue(new object[length]);
+            }
+        }
+    }
+}

--- a/Oxide.Core/ArrayPool.cs
+++ b/Oxide.Core/ArrayPool.cs
@@ -47,6 +47,10 @@ namespace Oxide.Core
             {
                 array[i] = null;
             }
+            if (_pooledArrays[array.Length].Count > MaxPoolAmount)
+            {
+                return;
+            }
             _pooledArrays[array.Length].Enqueue(array);
         }
 

--- a/Oxide.Core/ArrayPool.cs
+++ b/Oxide.Core/ArrayPool.cs
@@ -7,7 +7,7 @@ namespace Oxide.Core
 {
     public static class ArrayPool
     {
-        private const int MaxArrayLength = 10;
+        private const int MaxArrayLength = 50;
         private const int InitialPoolAmount = 64;
         private const int MaxPoolAmount = 256;
 
@@ -38,7 +38,7 @@ namespace Oxide.Core
 
         public static void Free(object[] array)
         {
-            if (array.Length == 0 || array.Length > MaxArrayLength)
+            if (array == null || array.Length == 0 || array.Length > MaxArrayLength)
             {
                 return;
             }
@@ -47,11 +47,11 @@ namespace Oxide.Core
             {
                 array[i] = null;
             }
-            if (_pooledArrays[array.Length].Count > MaxPoolAmount)
+            if (_pooledArrays[array.Length - 1].Count > MaxPoolAmount)
             {
                 return;
             }
-            _pooledArrays[array.Length].Enqueue(array);
+            _pooledArrays[array.Length - 1].Enqueue(array);
         }
 
         private static void SetupArrays(int length)

--- a/Oxide.Core/Interface.cs
+++ b/Oxide.Core/Interface.cs
@@ -60,7 +60,211 @@ namespace Oxide.Core
         /// <param name="hook"></param>
         /// <param name="args"></param>
         /// <returns></returns>
-        public static object CallHook(string hook, params object[] args) => Oxide?.CallHook(hook, args);
+        public static object CallHook(string hook, object[] args) => Oxide?.CallHook(hook, args);
+
+        //Using params creates a new object array every single time
+        //This leads to 5k-10k+ new object arrays each second
+        //Which then leads to frequent and expensive garbage collections, stalling the server
+        //Insted we will use overloads for 1-10 arguments. Anything above that shouldn't be needed
+
+        #region Hook Overloads
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object CallHook(string hook, object obj1)
+        {
+            var array = ArrayPool.Get(1);
+            array[0] = obj1;
+            object ret = CallHook(hook, array);
+            ArrayPool.Free(array);
+            return ret;
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object CallHook(string hook, object obj1, object obj2)
+        {
+            var array = ArrayPool.Get(2);
+            array[0] = obj1;
+            array[1] = obj2;
+            object ret = CallHook(hook, array);
+            ArrayPool.Free(array);
+            return ret;
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object CallHook(string hook, object obj1, object obj2, object obj3)
+        {
+            var array = ArrayPool.Get(3);
+            array[0] = obj1;
+            array[1] = obj2;
+            array[2] = obj3;
+            object ret = CallHook(hook, array);
+            ArrayPool.Free(array);
+            return ret;
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object CallHook(string hook, object obj1, object obj2, object obj3, object obj4)
+        {
+            var array = ArrayPool.Get(4);
+            array[0] = obj1;
+            array[1] = obj2;
+            array[2] = obj3;
+            array[3] = obj4;
+            object ret = CallHook(hook, array);
+            ArrayPool.Free(array);
+            return ret;
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object CallHook(string hook, object obj1, object obj2, object obj3, object obj4, object obj5)
+        {
+            var array = ArrayPool.Get(5);
+            array[0] = obj1;
+            array[1] = obj2;
+            array[2] = obj3;
+            array[3] = obj4;
+            array[4] = obj5;
+            object ret = CallHook(hook, array);
+            ArrayPool.Free(array);
+            return ret;
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object CallHook(string hook, object obj1, object obj2, object obj3, object obj4, object obj5, object obj6)
+        {
+            var array = ArrayPool.Get(6);
+            array[0] = obj1;
+            array[1] = obj2;
+            array[2] = obj3;
+            array[3] = obj4;
+            array[4] = obj5;
+            array[5] = obj6;
+            object ret = CallHook(hook, array);
+            ArrayPool.Free(array);
+            return ret;
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object CallHook(string hook, object obj1, object obj2, object obj3, object obj4, object obj5, object obj6, object obj7)
+        {
+            var array = ArrayPool.Get(7);
+            array[0] = obj1;
+            array[1] = obj2;
+            array[2] = obj3;
+            array[3] = obj4;
+            array[4] = obj5;
+            array[5] = obj6;
+            array[6] = obj7;
+            object ret = CallHook(hook, array);
+            ArrayPool.Free(array);
+            return ret;
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object CallHook(string hook, object obj1, object obj2, object obj3, object obj4, object obj5, object obj6, object obj7, object obj8)
+        {
+            var array = ArrayPool.Get(8);
+            array[0] = obj1;
+            array[1] = obj2;
+            array[2] = obj3;
+            array[3] = obj4;
+            array[4] = obj5;
+            array[5] = obj6;
+            array[6] = obj7;
+            array[7] = obj8;
+            object ret = CallHook(hook, array);
+            ArrayPool.Free(array);
+            return ret;
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object CallHook(string hook, object obj1, object obj2, object obj3, object obj4, object obj5, object obj6, object obj7, object obj8, object obj9)
+        {
+            var array = ArrayPool.Get(9);
+            array[0] = obj1;
+            array[1] = obj2;
+            array[2] = obj3;
+            array[3] = obj4;
+            array[4] = obj5;
+            array[5] = obj6;
+            array[6] = obj7;
+            array[7] = obj8;
+            array[8] = obj9;
+            object ret = CallHook(hook, array);
+            ArrayPool.Free(array);
+            return ret;
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static object CallHook(string hook, object obj1, object obj2, object obj3, object obj4, object obj5, object obj6, object obj7, object obj8, object obj9, object obj10)
+        {
+            var array = ArrayPool.Get(10);
+            array[0] = obj1;
+            array[1] = obj2;
+            array[2] = obj3;
+            array[3] = obj4;
+            array[4] = obj5;
+            array[5] = obj6;
+            array[6] = obj7;
+            array[7] = obj8;
+            array[8] = obj9;
+            array[9] = obj10;
+            object ret = CallHook(hook, array);
+            ArrayPool.Free(array);
+            return ret;
+        }
+
+        #endregion
 
         /// <summary>
         /// Calls the specified hook

--- a/Oxide.Core/Interface.cs
+++ b/Oxide.Core/Interface.cs
@@ -75,6 +75,17 @@ namespace Oxide.Core
         /// <param name="hook"></param>
         /// <param name="args"></param>
         /// <returns></returns>
+        public static object CallHook(string hook)
+        {
+            return CallHook(hook, null);
+        }
+
+        /// <summary>
+        /// Calls the specified hook
+        /// </summary>
+        /// <param name="hook"></param>
+        /// <param name="args"></param>
+        /// <returns></returns>
         public static object CallHook(string hook, object obj1)
         {
             var array = ArrayPool.Get(1);

--- a/Oxide.Core/Plugins/CSPlugin.cs
+++ b/Oxide.Core/Plugins/CSPlugin.cs
@@ -229,6 +229,7 @@ namespace Oxide.Core.Plugins
         protected sealed override object OnCallHook(string name, object[] args)
         {
             object returnvalue = null;
+            bool pooledArray = false;
             
             // Call all hooks that match the signature
             foreach (var h in FindHooks(name, args))
@@ -240,6 +241,7 @@ namespace Oxide.Core.Plugins
                 {
                     // The call argument count is different to the declared callback methods argument count
                     hookArgs = ArrayPool.Get(h.Parameters.Length);
+                    pooledArray = true;
 
                     if (received > 0 && hookArgs.Length > 0)
                     {
@@ -293,7 +295,11 @@ namespace Oxide.Core.Plugins
                         }
                     }
                 }
-                ArrayPool.Free(hookArgs);
+
+                if (pooledArray)
+                {
+                    ArrayPool.Free(hookArgs);
+                }
             }
 
             return returnvalue;
@@ -370,6 +376,8 @@ namespace Oxide.Core.Plugins
                             }
                         }
                     }
+
+                    ArrayPool.Free(hookArgs);
                 }
                 else
                 {
@@ -389,7 +397,7 @@ namespace Oxide.Core.Plugins
                     overloadedMatch = h;
                 }
 
-                ArrayPool.Free(hookArgs);
+                
             }
 
             if (exactMatch != null)

--- a/Oxide.Core/Plugins/CSPlugin.cs
+++ b/Oxide.Core/Plugins/CSPlugin.cs
@@ -239,7 +239,7 @@ namespace Oxide.Core.Plugins
                 if (received != h.Parameters.Length)
                 {
                     // The call argument count is different to the declared callback methods argument count
-                    hookArgs = new object[h.Parameters.Length];
+                    hookArgs = ArrayPool.Get(h.Parameters.Length);
 
                     if (received > 0 && hookArgs.Length > 0)
                     {
@@ -277,6 +277,7 @@ namespace Oxide.Core.Plugins
                 }
                 catch (TargetInvocationException ex)
                 {
+                    ArrayPool.Free(hookArgs);
                     throw ex.InnerException ?? ex;
                 }
 
@@ -292,6 +293,7 @@ namespace Oxide.Core.Plugins
                         }
                     }
                 }
+                ArrayPool.Free(hookArgs);
             }
 
             return returnvalue;

--- a/Oxide.Core/Plugins/CSPlugin.cs
+++ b/Oxide.Core/Plugins/CSPlugin.cs
@@ -165,7 +165,10 @@ namespace Oxide.Core.Plugins
                 }
                 catch (TargetInvocationException ex)
                 {
-                    ArrayPool.Free(hookArgs);
+                    if (pooledArray)
+                    {
+                        ArrayPool.Free(hookArgs);
+                    }
                     throw ex.InnerException ?? ex;
                 }
 

--- a/Oxide.Core/Plugins/CSPlugin.cs
+++ b/Oxide.Core/Plugins/CSPlugin.cs
@@ -344,7 +344,7 @@ namespace Oxide.Core.Plugins
                 if (received != h.Parameters.Length)
                 {
                     // The call argument count is different to the declared callback methods argument count
-                    hookArgs = new object[h.Parameters.Length];
+                    hookArgs = ArrayPool.Get(h.Parameters.Length);
 
                     if (received > 0 && hookArgs.Length > 0)
                     {
@@ -370,6 +370,7 @@ namespace Oxide.Core.Plugins
                             }
                         }
                     }
+                    ArrayPool.Free(hookArgs);
                 }
                 else
                 {

--- a/Oxide.Core/Plugins/CSPlugin.cs
+++ b/Oxide.Core/Plugins/CSPlugin.cs
@@ -33,120 +33,6 @@ namespace Oxide.Core.Plugins
     /// </summary>
     public abstract class CSPlugin : Plugin
     {
-        public class HookMethod
-        {
-            public string Name;
-
-            public MethodInfo Method;
-
-            public ParameterInfo[] Parameters => Method.GetParameters();
-
-            public bool IsBaseHook => Name.StartsWith("base_");
-
-            public HookMethod(MethodInfo method)
-            {
-                Method = method;
-                Name = method.Name;
-
-                if (Parameters.Length > 0)
-                {
-                    Name += $"({string.Join(", ", Parameters.Select(x => x.ParameterType.ToString()).ToArray())})";
-                }
-            }
-            
-            public bool HasMatchingSignature(object[] args, out bool exact)
-            {
-                exact = true;
-
-                if (Parameters.Length == 0 && (args == null || args.Length == 0))
-                    return true;
-
-                for (var i = 0; i < args.Length; i++)
-                {
-                    if (args[i] == null)
-                    {
-                        if (CanAssignNull(Parameters[i].ParameterType))
-                        {
-                            continue;
-                        }
-
-                        return false;
-                    }
-
-                    if (exact)
-                    {
-                        if (args[i].GetType() != Parameters[i].ParameterType &&
-                            args[i].GetType().MakeByRefType() != Parameters[i].ParameterType &&
-                            !CanConvertNumber(args[i], Parameters[i].ParameterType))
-                        {
-                            exact = false;
-                        }
-                    }
-
-                    if (exact) continue;
-
-                    if (args[i].GetType() == Parameters[i].ParameterType ||
-                        args[i].GetType().MakeByRefType() == Parameters[i].ParameterType ||
-                        Parameters[i].ParameterType.FullName == "System.Object")
-                    {
-                        continue;
-                    }
-
-                    if (args[i].GetType().IsValueType)
-                    {
-                        if (!TypeDescriptor.GetConverter(Parameters[i].ParameterType).CanConvertFrom(args[i].GetType()) && !CanConvertNumber(args[i], Parameters[i].ParameterType))
-                        {
-                            return false;
-                        }
-                    }
-                    else
-                    {
-                        if (!Parameters[i].ParameterType.IsInstanceOfType(args[i]))
-                        {
-                            return false;
-                        }
-                    }
-                }
-
-                return true;
-            }
-            
-            private bool CanAssignNull(Type type)
-            {
-                if (!type.IsValueType)
-                {
-                    return true;
-                }
-
-                return Nullable.GetUnderlyingType(type) != null;
-            }
-
-            private bool IsNumber(object obj)
-            {
-                return obj != null && IsNumber(Nullable.GetUnderlyingType(obj.GetType()) ?? obj.GetType());
-            }
-
-            private bool IsNumber(Type type)
-            {
-                if (type.IsPrimitive)
-                {
-                    return type != typeof(bool) && type != typeof(char) && type != typeof(IntPtr) && type != typeof(UIntPtr);
-                }
-
-                return type == typeof(decimal);
-            }
-
-            private bool CanConvertNumber(object value, Type type)
-            {
-                if (!IsNumber(value) || !IsNumber(type))
-                {
-                    return false;
-                }
-
-                return TypeDescriptor.GetConverter(type).IsValid(value);
-            }
-        }
-
         /// <summary>
         /// Gets the library by the specified type or name
         /// </summary>
@@ -158,7 +44,7 @@ namespace Oxide.Core.Plugins
         protected Dictionary<string, List<HookMethod>> Hooks = new Dictionary<string, List<HookMethod>>();
 
         // All matched hooked methods
-        protected Dictionary<string, List<HookMethod>> HooksCache = new Dictionary<string, List<HookMethod>>();
+        protected HookCache HooksCache = new HookCache();
 
         /// <summary>
         /// Initializes a new instance of the CSPlugin class
@@ -230,7 +116,7 @@ namespace Oxide.Core.Plugins
         {
             object returnvalue = null;
             bool pooledArray = false;
-            
+
             // Call all hooks that match the signature
             foreach (var h in FindHooks(name, args))
             {
@@ -308,21 +194,15 @@ namespace Oxide.Core.Plugins
         protected List<HookMethod> FindHooks(string name, object[] args)
         {
             // Get the full name of the hook `name(argument type 1, argument type 2, ..., argument type x)`
-            var fullName = name;
-            if (args?.Length > 0)
-            {
-                fullName += $"({string.Join(", ", args.Select(x => x?.GetType().ToString() ?? "null").ToArray())})";
-            }
 
             // Check the cache if we already found a match for this hook
-            if (HooksCache.ContainsKey(fullName))
+            HookCache cache;
+            List<HookMethod> methods = HooksCache.GetHookMethod(name, args, out cache);
+            if (methods != null)
             {
-                return HooksCache[fullName];
+                return methods;
             }
-
-            List<HookMethod> methods;
             var matches = new List<HookMethod>();
-
             // Get all hook methods that could match, return an empty list if none match
             if (!Hooks.TryGetValue(name, out methods))
             {
@@ -377,8 +257,8 @@ namespace Oxide.Core.Plugins
                         }
                     }
 
-                    ArrayPool.Free(hookArgs);
-                }
+                        ArrayPool.Free(hookArgs);
+               }
                 else
                 {
                     hookArgs = args;
@@ -396,8 +276,6 @@ namespace Oxide.Core.Plugins
                     // Should we determine the level and call the closest overloaded match? Performance impact?
                     overloadedMatch = h;
                 }
-
-                
             }
 
             if (exactMatch != null)
@@ -412,7 +290,9 @@ namespace Oxide.Core.Plugins
                 }
             }
 
-            return HooksCache[fullName] = matches;
+            cache.SetupMethods(matches);
+
+            return matches;
         }
 
         protected virtual object InvokeMethod(HookMethod method, object[] args) => method.Method.Invoke(this, args);

--- a/Oxide.Core/Plugins/CSPlugin.cs
+++ b/Oxide.Core/Plugins/CSPlugin.cs
@@ -230,10 +230,13 @@ namespace Oxide.Core.Plugins
                 object[] hookArgs;
                 var received = args?.Length ?? 0;
 
+                bool pooledArray = false;
+
                 if (received != h.Parameters.Length)
                 {
                     // The call argument count is different to the declared callback methods argument count
                     hookArgs = ArrayPool.Get(h.Parameters.Length);
+                    pooledArray = true;
 
                     if (received > 0 && hookArgs.Length > 0)
                     {
@@ -259,9 +262,7 @@ namespace Oxide.Core.Plugins
                             }
                         }
                     }
-
-                        ArrayPool.Free(hookArgs);
-               }
+                }
                 else
                 {
                     hookArgs = args;
@@ -278,6 +279,11 @@ namespace Oxide.Core.Plugins
 
                     // Should we determine the level and call the closest overloaded match? Performance impact?
                     overloadedMatch = h;
+                }
+
+                if (pooledArray)
+                {
+                    ArrayPool.Free(hookArgs);
                 }
             }
 

--- a/Oxide.Core/Plugins/CSPlugin.cs
+++ b/Oxide.Core/Plugins/CSPlugin.cs
@@ -370,7 +370,6 @@ namespace Oxide.Core.Plugins
                             }
                         }
                     }
-                    ArrayPool.Free(hookArgs);
                 }
                 else
                 {
@@ -389,6 +388,8 @@ namespace Oxide.Core.Plugins
                     // Should we determine the level and call the closest overloaded match? Performance impact?
                     overloadedMatch = h;
                 }
+
+                ArrayPool.Free(hookArgs);
             }
 
             if (exactMatch != null)

--- a/Oxide.Core/Plugins/HookCache.cs
+++ b/Oxide.Core/Plugins/HookCache.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Oxide.Core.Plugins
+{
+    public class HookCache
+    {
+        private string NullKey = "null";
+
+        public Dictionary<string, HookCache> _cache = new Dictionary<string, HookCache>();
+
+        public List<HookMethod> _methods = null;
+
+        public List<HookMethod> GetHookMethod(string hookName, object [] args, out HookCache cache)
+        {
+            HookCache nextCache;
+            //Interface.Oxide.ServerConsole.AddMessage($"GetHookMethod {hookName}");
+            if (!_cache.TryGetValue(hookName, out nextCache))
+            {
+                nextCache = new HookCache();
+                _cache.Add(hookName, nextCache);
+            }
+            return nextCache.GetHookMethod(args, 0, out cache);
+        }
+
+        public List<HookMethod> GetHookMethod(object[] args, int index, out HookCache cache)
+        {
+            if (args == null || index >= args.Length)
+            {
+                cache = this;
+                return _methods;
+            }
+            HookCache nextCache;
+            if (args[index] == null)
+            {
+                if (!_cache.TryGetValue(NullKey, out nextCache))
+                {
+                    nextCache = new HookCache();
+                    _cache.Add(NullKey, nextCache);
+                }
+            }
+            else
+            {
+                if (!_cache.TryGetValue(args[index].GetType().FullName, out nextCache))
+                {
+                    nextCache = new HookCache();
+                    _cache.Add(args[index].GetType().FullName, nextCache);
+                }
+            }
+            //Interface.Oxide.ServerConsole.AddMessage($"GetHookMethod {key} {index}");
+            return nextCache.GetHookMethod(args, index + 1, out cache);
+        }
+
+        public void SetupMethods(List<HookMethod> methods)
+        {
+            _methods = methods;
+        }
+    }
+}

--- a/Oxide.Core/Plugins/HookMethod.cs
+++ b/Oxide.Core/Plugins/HookMethod.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Oxide.Core.Plugins
+{
+    public class HookMethod
+    {
+        public string Name;
+
+        public MethodInfo Method;
+
+        public ParameterInfo[] Parameters { get; set; }
+
+        public bool IsBaseHook { get; set; }
+
+        public HookMethod(MethodInfo method)
+        {
+            Method = method;
+            Name = method.Name;
+
+            Parameters = Method.GetParameters();
+
+            if (Parameters.Length > 0)
+            {
+                Name += $"({string.Join(", ", Parameters.Select(x => x.ParameterType.ToString()).ToArray())})";
+            }
+
+            IsBaseHook = Name.StartsWith("base_");
+        }
+
+        public bool HasMatchingSignature(object[] args, out bool exact)
+        {
+            exact = true;
+
+            if (Parameters.Length == 0 && (args == null || args.Length == 0))
+                return true;
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                if (args[i] == null)
+                {
+                    if (CanAssignNull(Parameters[i].ParameterType))
+                    {
+                        continue;
+                    }
+
+                    return false;
+                }
+
+                if (exact)
+                {
+                    if (args[i].GetType() != Parameters[i].ParameterType &&
+                        args[i].GetType().MakeByRefType() != Parameters[i].ParameterType &&
+                        !CanConvertNumber(args[i], Parameters[i].ParameterType))
+                    {
+                        exact = false;
+                    }
+                }
+
+                if (exact) continue;
+
+                if (args[i].GetType() == Parameters[i].ParameterType ||
+                    args[i].GetType().MakeByRefType() == Parameters[i].ParameterType ||
+                    Parameters[i].ParameterType.FullName == "System.Object")
+                {
+                    continue;
+                }
+
+                if (args[i].GetType().IsValueType)
+                {
+                    if (!TypeDescriptor.GetConverter(Parameters[i].ParameterType).CanConvertFrom(args[i].GetType()) && !CanConvertNumber(args[i], Parameters[i].ParameterType))
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (!Parameters[i].ParameterType.IsInstanceOfType(args[i]))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private bool CanAssignNull(Type type)
+        {
+            if (!type.IsValueType)
+            {
+                return true;
+            }
+
+            return Nullable.GetUnderlyingType(type) != null;
+        }
+
+        private bool IsNumber(object obj)
+        {
+            return obj != null && IsNumber(Nullable.GetUnderlyingType(obj.GetType()) ?? obj.GetType());
+        }
+
+        private bool IsNumber(Type type)
+        {
+            if (type.IsPrimitive)
+            {
+                return type != typeof(bool) && type != typeof(char) && type != typeof(IntPtr) && type != typeof(UIntPtr);
+            }
+
+            return type == typeof(decimal);
+        }
+
+        private bool CanConvertNumber(object value, Type type)
+        {
+            if (!IsNumber(value) || !IsNumber(type))
+            {
+                return false;
+            }
+
+            return TypeDescriptor.GetConverter(type).IsValid(value);
+        }
+    }
+
+}

--- a/Oxide.Core/Plugins/PluginManager.cs
+++ b/Oxide.Core/Plugins/PluginManager.cs
@@ -146,7 +146,7 @@ namespace Oxide.Core.Plugins
             if (plugins.Count == 0) return null;
 
             // Loop each item
-            var values = new object[plugins.Count];
+            var values = ArrayPool.Get(plugins.Count);
             var returnCount = 0;
             object finalValue = null;
             Plugin finalPlugin = null;
@@ -191,6 +191,7 @@ namespace Oxide.Core.Plugins
                     Logger.Write(LogType.Warning, "Calling hook {0} resulted in a conflict between the following plugins: {1}", hook, string.Join(", ", hookConflicts.ToArray()));
                 }
             }
+            ArrayPool.Free(values);
 
             return finalValue;
         }

--- a/Oxide.Core/Plugins/PluginManager.cs
+++ b/Oxide.Core/Plugins/PluginManager.cs
@@ -164,7 +164,11 @@ namespace Oxide.Core.Plugins
             }
 
             // Is there a return value?
-            if (returnCount == 0) return null;
+            if (returnCount == 0)
+            {
+                ArrayPool.Free(values);
+                return null;
+            }
 
             if (returnCount > 1 && finalValue != null)
             {


### PR DESCRIPTION
Oxide has had an issue with creating tons of unnecessary garbage for a long time. 

A Oxide server will have severe garbage collects of 1000ms+ every 1-2 minutes, while a comparable vanilla server will have small garbage collects every 15-30 minutes. 

This is because every Interface.CallHook() will create a new object array, regardless if the hook is being used or not. For hooks that are used, it will create even more object arrays. There can be anywhere from 5k - 20k+ arrays created per second, leading to the massive stalling on garbage collects.

This changes Interface.CallHook() to pass parameters through overloads, take an array from a Pool, call the hook and then return the array back to the Pool. 

Arrays are pooled in other areas such as hook conflicts and when filling in required parameters.

An additional pull request was made to the patcher to allow it to use overloads instead of params.

Patcher pull request can be found here: https://github.com/OxideMod/Oxide.Patcher/pull/138

**Hook Calls Between Garbage Collects (Depends on RAM usage)**

**Old:**
Non-Subscribed Hook: 3.6M Calls 
Subscribed Hook: 0.2M Calls

**New:**
Non-Subscribed Hook: 600M+ Calls 
Subscribed Hook: 600M+ Calls