### PR TITLE
DataFileSystem: new method 'GetFileString' to read files to strings

### DIFF
--- a/src/DataFileSystem.cs
+++ b/src/DataFileSystem.cs
@@ -42,9 +42,15 @@ namespace Oxide.Core
         /// <returns>Content string or null if file wasn't found</returns>
         public string GetFileString(string fileName)
         {
+            // prepare path to file
             fileName = DynamicConfigFile.SanitizeName(fileName);
-            var filePath = Path.Combine(Directory, fileName);
+            var filePath = Path.GetFullPath(Path.Combine(Directory, fileName));
 
+            // check if path is correct
+            if (!filePath.StartsWith(Directory))
+                throw new FileLoadException($"Only access to directory: {Directory}");
+
+            // check if file exists
             if (!File.Exists(filePath))
                 throw new FileNotFoundException($"File '{filePath}' not found");
 

--- a/src/DataFileSystem.cs
+++ b/src/DataFileSystem.cs
@@ -35,6 +35,23 @@ namespace Oxide.Core
             settings.Converters.Add(converter);
         }
 
+        /// <summary>
+        /// Read file as string from Data directory
+        /// </summary>
+        /// <param name="fileName">Name of file (eg. MyData.json)</param>
+        /// <returns>Content string or null if file wasn't found</returns>
+        public string GetFileString(string fileName)
+        {
+            fileName = DynamicConfigFile.SanitizeName(fileName);
+            var filePath = Path.Combine(Directory, fileName);
+
+            if (!File.Exists(filePath))
+                throw new FileNotFoundException($"File '{filePath}' not found");
+
+            var result = File.ReadAllText(filePath);
+            return result;
+        }
+
         public DynamicConfigFile GetFile(string name)
         {
             name = DynamicConfigFile.SanitizeName(name);

--- a/src/DataFileSystem.cs
+++ b/src/DataFileSystem.cs
@@ -39,7 +39,7 @@ namespace Oxide.Core
         /// Read file as string from Data directory
         /// </summary>
         /// <param name="fileName">Name of file (eg. MyData.json)</param>
-        /// <returns>Content string or null if file wasn't found</returns>
+        /// <returns>Content string</returns>
         public string GetFileString(string fileName)
         {
             // prepare path to file


### PR DESCRIPTION
To make possible read JSON files as strings, I've added a new method to do it.

### Usage example:
I want read JSON string from data file to use it with **CuiHelper.FromJson(...)** method.
Cause now it looks like we have CuiHelper method to build UI from JSON specification, but we can't read this specification from local.

So, with this new method **GetFileString(...)** we can do it now like this:
```C#
private void Example()
{
    var filePath = $"{GetType().Name}/profile-menu.json";
    var data = Interface.Oxide.DataFileSystem.GetFileString(filePath);

    // now you can use this string as template for your UI, 
    // replace some placeholders and send it to CuiHelper.FromJson(...) method

    Puts(data);
}
```