### PR TITLE
Fixes child groups being orphaned when their parent has been removed.

### DIFF
--- a/src/Libraries/Permission.cs
+++ b/src/Libraries/Permission.cs
@@ -4,6 +4,7 @@ using Oxide.Core.Plugins;
 using References::ProtoBuf;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Linq;
 
@@ -987,6 +988,15 @@ namespace Oxide.Core.Libraries
 
             // Remove the group
             bool removed = groupdata.Remove(group);
+
+            if (removed)
+            {
+                // Set children to having no parent group
+                foreach (var child in groupdata.Values.Where(x => x.ParentGroup == group))
+                {
+                    child.ParentGroup = String.Empty;
+                }
+            }
 
             // Remove group from users
             bool changed = userdata.Values.Aggregate(false, (current, userData) => current | userData.Groups.Remove(group));


### PR DESCRIPTION
When removing a group, if it has children, the children will be orphaned breaking the logical tree. 

Current behavior traverses the tree of parents until it can't find that parent that doesn't exist, ending traversal. This fixes the issue by making the group top-level, resulting in the same behavior for compatibility and still retaining a logical tree. 

Other options include changing the orphaned groups parent to the deleted groups parent, though this may break some implementations as it results in a different behavior than the current implementation. Could also just delete the child group but that seems boorish compared to current behavior.