### PR TITLE
Utility methods for OxideMod and ExtensionManager

### DIFF
--- a/src/Extensions/ExtensionManager.cs
+++ b/src/Extensions/ExtensionManager.cs
@@ -363,6 +363,13 @@ namespace Oxide.Core.Extensions
         public bool IsExtensionPresent(string name) => extensions.Any(e => e.Name == name);
 
         /// <summary>
+        /// Returns if an extension of the given type is present
+        /// </summary>
+        /// <typeparam name="T">Extension type</typeparam>
+        /// <returns></returns>
+        public bool IsExtensionPresent<T>() where T : Extension => extensions.Any(e => e is T);
+
+        /// <summary>
         /// Gets the extension by the given name
         /// </summary>
         /// <param name="name"></param>

--- a/src/Extensions/ExtensionManager.cs
+++ b/src/Extensions/ExtensionManager.cs
@@ -378,5 +378,15 @@ namespace Oxide.Core.Extensions
                 return null;
             }
         }
+
+        /// <summary>
+        /// Gets the extension by the given type
+        /// </summary>
+        /// <typeparam name="T">Extension type</typeparam>
+        /// <returns>Extension of type <typeparamref name="T"/> if it's present, otherwise <see langword="null"/></returns>
+        public T GetExtension<T>() where T : Extension
+        {
+            return (T)extensions.FirstOrDefault(e => e is T);
+        }
     }
 }

--- a/src/OxideMod.cs
+++ b/src/OxideMod.cs
@@ -284,7 +284,7 @@ namespace Oxide.Core
         public IEnumerable<Extension> GetAllExtensions() => extensionManager.GetAllExtensions();
 
         /// <summary>
-        /// Gets all loaded extensions
+        /// Gets all present plugin loaders
         /// </summary>
         /// <returns></returns>
         public IEnumerable<PluginLoader> GetPluginLoaders() => extensionManager.GetPluginLoaders();

--- a/src/OxideMod.cs
+++ b/src/OxideMod.cs
@@ -284,6 +284,20 @@ namespace Oxide.Core
         public IEnumerable<Extension> GetAllExtensions() => extensionManager.GetAllExtensions();
 
         /// <summary>
+        /// Gets an extension by name if it's loaded
+        /// </summary>
+        /// <param name="name">Extension name</param>
+        /// <returns></returns>
+        public Extension GetExtension(string name) => extensionManager.GetExtension(name);
+
+        /// <summary>
+        /// Gets an extension by type if it's present
+        /// </summary>
+        /// <typeparam name="T">Extension type</typeparam>
+        /// <returns></returns>
+        public T GetExtension<T>() where T : Extension => extensionManager.GetExtension<T>();
+
+        /// <summary>
         /// Gets all present plugin loaders
         /// </summary>
         /// <returns></returns>


### PR DESCRIPTION
## ExtensionManager
- Add `T GetExtension<T>()` method: similar to Extension `GetExtension(string)`, but gets an extension by the specified type
- Add `bool IsExtensionPresent<T>()` method: same as above
## OxideMod
Exposed `GetExtension(string)` and `GetExtension<T>()` methods from `extensionManager`