### PR TITLE
Change detect internal hooks

### DIFF
--- a/src/Plugins/PluginManager.cs
+++ b/src/Plugins/PluginManager.cs
@@ -120,7 +120,7 @@ namespace Oxide.Core.Plugins
         /// <param name="plugin"></param>
         internal void SubscribeToHook(string hook, Plugin plugin)
         {
-            if (!loadedPlugins.ContainsKey(plugin.Name) || !plugin.IsCorePlugin && hook.StartsWith("I"))
+            if (!loadedPlugins.ContainsKey(plugin.Name) || !plugin.IsCorePlugin && (hook.StartsWith("IOn") || hook.StartsWith("ICan")))
             {
                 return;
             }

--- a/src/Plugins/PluginManager.cs
+++ b/src/Plugins/PluginManager.cs
@@ -144,7 +144,7 @@ namespace Oxide.Core.Plugins
         /// <param name="plugin"></param>
         internal void UnsubscribeToHook(string hook, Plugin plugin)
         {
-            if (!loadedPlugins.ContainsKey(plugin.Name) || !plugin.IsCorePlugin && hook.StartsWith("I"))
+            if (!loadedPlugins.ContainsKey(plugin.Name) || !plugin.IsCorePlugin && (hook.StartsWith("IOn") || hook.StartsWith("ICan")))
             {
                 return;
             }


### PR DESCRIPTION
All internal hooks started string `ICan` or `IOn`.
Some developers use hooks on starts `I`, example `IsEventPlayer`. 
Which may not be called due to this condition.