### PR TITLE
Update OxideConfig.cs

### DIFF
--- a/src/Configuration/OxideConfig.cs
+++ b/src/Configuration/OxideConfig.cs
@@ -107,7 +107,7 @@ namespace Oxide.Core.Configuration
         public OxideConfig(string filename) : base(filename)
         {
             Options = new OxideOptions { Modded = true, PluginWatchers = true, DefaultGroups = new DefaultGroups { Administrators = "admin", Players = "default" }, WebRequestIP = "0.0.0.0" };
-            Console = new OxideConsole { Enabled = true, MinimalistMode = true, ShowStatusBar = true };
+            Console = new OxideConsole { Enabled = false, MinimalistMode = true, ShowStatusBar = true };
             Rcon = new OxideRcon { Enabled = false, ChatPrefix = "[Server Console]", Port = 25580, Password = string.Empty };
         }
     }


### PR DESCRIPTION
ref: discord conversation: https://discord.com/channels/500413814244638747/758543626069737503/1102641675236552765

> willman42 — Today at 1:04 PM
> what's the diff between OxideConsole and OxideRcon in oxide.config.json? By default it looks like OxideConsole is enabled and OxideRcon is not Mr. Blue — Today at 1:04 PM
> Both should be disabled by default for Rust
> Because Rust provides both