### PR TITLE
Parse empty files

### DIFF
--- a/src/DataFileSystem.cs
+++ b/src/DataFileSystem.cs
@@ -98,14 +98,18 @@ namespace Oxide.Core
 
         public T ReadObject<T>(string name)
         {
-            if (!ExistsDatafile(name))
+            T instance = default;
+
+            if (ExistsDatafile(name))
+                instance = GetFile(name).ReadObject<T>();
+
+            if (instance == null)
             {
-                T instance = Activator.CreateInstance<T>();
+                instance = Activator.CreateInstance<T>();
                 WriteObject(name, instance);
-                return instance;
             }
 
-            return GetFile(name).ReadObject<T>();
+            return instance;
         }
 
         public void WriteObject<T>(string name, T Object, bool sync = false) => GetFile(name).WriteObject(Object, sync);


### PR DESCRIPTION
## Issue
Sometimes, a config/data file will exist, but will be empty. Parsing those files as T returns null. It should instead return a new instance of T as it would if the file didn't exist.