### PR TITLE
Fix NRE with auto patch logging when using reverse patches

### DIFF
--- a/src/Plugins/CSPlugin.cs
+++ b/src/Plugins/CSPlugin.cs
@@ -160,6 +160,12 @@ namespace Oxide.Core.Plugins
 
                     foreach (MethodInfo method in harmonyMethods)
                     {
+                        // the MethodInfo is null when the list of methods contains a reverse patched method
+                        if (method == null)
+                        {
+                            continue;
+                        }
+
                         Interface.Oxide.LogInfo($"[{Title}] Automatically Harmony patched '{method.Name}' method. ({nestedType.Name})");
                     }
                 }


### PR DESCRIPTION
For some reason when using a reverse patch with Harmony, the returned list of patched methods will include a null value causing oxide to throw an NRE when logging the patched methods to console. I've added a null check on the MethodInfo to resolve the problem.