### PR TITLE
Hook conflicts and the call order of hooks in plugins

### DIFF
--- a/src/Oxide.Core.csproj
+++ b/src/Oxide.Core.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Lib.Harmony" Version="2.3.1.1" />
-    <PackageReference Include="Oxide.Common" Version="2.0.37-develop" />
+    <PackageReference Include="Oxide.Common" Version="2.0.38-develop" />
     <PackageReference Include="Oxide.References" Version="2.0.*">
       <PrivateAssets>contentfiles;analyzers;build</PrivateAssets>
     </PackageReference>

--- a/src/Oxide.Core.csproj
+++ b/src/Oxide.Core.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Lib.Harmony" Version="2.3.1.1" />
-    <PackageReference Include="Oxide.Common" Version="2.0.*" />
+    <PackageReference Include="Oxide.Common" Version="2.0.37-develop" />
     <PackageReference Include="Oxide.References" Version="2.0.*">
       <PrivateAssets>contentfiles;analyzers;build</PrivateAssets>
     </PackageReference>

--- a/src/Plugins/Plugin.cs
+++ b/src/Plugins/Plugin.cs
@@ -185,16 +185,28 @@ namespace Oxide.Core.Plugins
         }
 
         /// <summary>
-        /// Subscribes this plugin to the specified hook
+        /// Subscribes this plugin to the specified hook.
+        /// If the plugin is already subscribed to the given hook and the index is >= 0,
+        /// the plugin will be moved to the specified index in the subscription list.
+        /// If the index is -1, the plugin will be appended to the end of the list.
         /// </summary>
-        /// <param name="hook"></param>
-        protected void Subscribe(string hook) => Manager.SubscribeToHook(hook, this);
+        /// <param name="hookName">The hook to subscribe to</param>
+        /// <param name="subIndex">The index in the subscription list where the plugin should be moved to, if >= 0. Default is -1(append to the end)</param>
+        protected void Subscribe(string hookName, int subIndex = -1) => Manager.SubscribeToHook(hookName, this, subIndex);
+
 
         /// <summary>
-        /// Unsubscribes this plugin to the specified hook
+        /// Unsubscribes this plugin from the specified hook
         /// </summary>
-        /// <param name="hook"></param>
-        protected void Unsubscribe(string hook) => Manager.UnsubscribeToHook(hook, this);
+        /// <param name="hookName">The hook to unsubscribe from</param>
+        protected void Unsubscribe(string hookName) => Manager.UnsubscribeFromHook(hookName, this);
+
+        /// <summary>
+        /// Adding the expected type for the hook. Works only for standard hooks(On and Can)
+        /// </summary>
+        /// <param name="hookName">The name of the hook to which it needs to be added</param>
+        /// <param name="type">The type that needs to be added</param>
+        public void AddTypeToHook(string hookName, Type type) => Manager.AddTypeToHook(hookName, type);
 
         /// <summary>
         /// Called when this plugin has been added to the specified manager

--- a/src/Plugins/PluginManager.cs
+++ b/src/Plugins/PluginManager.cs
@@ -24,10 +24,13 @@ namespace Oxide.Core.Plugins
 
             public SubscriptionChangeType Change { get; }
 
-            public SubscriptionChange(Plugin plugin, SubscriptionChangeType type)
+            public int Index { get; }
+
+            public SubscriptionChange(Plugin plugin, SubscriptionChangeType type, int subIndex = -1)
             {
                 Plugin = plugin;
                 Change = type;
+                Index = subIndex;
             }
         }
 
@@ -37,13 +40,22 @@ namespace Oxide.Core.Plugins
 
             public int CallDepth { get; set; }
 
+            public bool IsStandartHook { get; }
+
+            public HashSet<Type> ExpectedTypes { get; }
+
             public Queue<SubscriptionChange> PendingChanges { get; }
 
-            public HookSubscriptions()
+            public HookSubscriptions(HashSet<Type> types = null)
             {
                 Plugins = new List<Plugin>();
-                PendingChanges = new Queue<SubscriptionChange>();
                 CallDepth = 0;
+                if (types != null)
+                {
+                    IsStandartHook = true;
+                    ExpectedTypes = types;
+                }
+                PendingChanges = new Queue<SubscriptionChange>();
             }
         }
 
@@ -74,12 +86,35 @@ namespace Oxide.Core.Plugins
         private readonly IDictionary<string, HookSubscriptions> hookSubscriptions;
 
         // Stores the last time a deprecation warning was printed for a specific hook
-        private readonly Dictionary<string, float> lastDeprecatedWarningAt = new Dictionary<string, float>();
+        private readonly Dictionary<string, float> nextDeprecatedWarningAt = new Dictionary<string, float>();
 
         // Re-usable conflict list used for hook calls
         private readonly List<string> hookConflicts = new List<string>();
 
+        // A list of hooks(where conflicts exist between plugins) with the time for the next conflict check
+        private readonly Dictionary<string, float> nextHookConflictsCheckAt = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
+
         private IArrayPoolProvider<object> ObjectPool { get; }
+
+        // Dictionary of saved types with their associated hooks
+        private readonly Dictionary<Type, HashSet<string>> expectedHookTypes = new Dictionary<Type, HashSet<string>>()
+        {
+            { typeof(bool), new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "OnSaveLoad", "OnEntityActiveCheck", "OnEntityDistanceCheck", "OnEntityFromOwnerCheck", "OnEntityVisibilityCheck",
+                "OnAIBrainStateSwitch", "OnEyePosValidate", "OnFuelCheck", "OnHorseHitch", "OnItemCraft",
+                "OnMagazineReload", "OnPurchaseItem", "OnVendingTransaction", "OnWireClear", "OnRackedWeaponMount"
+            } },
+            { typeof(int), new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "OnFuelGetAmount", "OnFuelUse", "OnInventoryItemsCount", "OnInventoryItemsTake", "OnItemResearched",
+                "OnItemUse", "OnMaxStackable", "OnResearchCostDetermine"
+            } },
+            { typeof(float), new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "OnOvenTemperature", "OnExplosiveFuseSet"
+            } }
+        };
 
         /// <summary>
         /// Initializes a new instance of the PluginManager class
@@ -91,6 +126,28 @@ namespace Oxide.Core.Plugins
             loadedPlugins = new Dictionary<string, Plugin>();
             hookSubscriptions = new Dictionary<string, HookSubscriptions>();
             Logger = logger;
+
+            // Safe addition of default types unknown to PluginManager
+            AddDefaultHookTypes("Item, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
+                "OnItemSplit", "OnFuelItemCheck", "OnFindBurnable", "OnInventoryItemFind", "OnInventoryAmmoItemFind", "OnDispenserBonus", "OnQuarryConsumeFuel", "OnFishCatch");
+            AddDefaultHookTypes("BuildingPrivlidge, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "OnBuildingPrivilege");
+            AddDefaultHookTypes("BaseCorpse, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "OnCorpsePopulate");
+            AddDefaultHookTypes("SleepingBag, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "OnPlayerRespawn");
+            AddDefaultHookTypes("BasePlayer+SpawnPoint, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "OnFindSpawnPoint", "OnPlayerRespawn");
+            AddDefaultHookTypes("ItemContainer+CanAcceptResult, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", "CanAcceptItem");
+
+            string listType = System.Text.RegularExpressions.Regex.Replace(typeof(List<int>).AssemblyQualifiedName, @"\[\[.*?\]\]", "[[{0}]]");
+            AddDefaultHookTypes(string.Format(listType, "Item, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"), "OnInventoryItemsFind");
+            AddDefaultHookTypes(string.Format(listType, "UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"), "OnBoatPathGenerate");
+
+            void AddDefaultHookTypes(string typeName, params string[] hooks)
+            {
+                var type = Type.GetType(typeName);
+                if (type != null)
+                {
+                    expectedHookTypes[type] = new HashSet<string>(hooks, StringComparer.OrdinalIgnoreCase);
+                }
+            }
         }
 
         /// <summary>
@@ -157,50 +214,52 @@ namespace Oxide.Core.Plugins
         public IEnumerable<Plugin> GetPlugins() => loadedPlugins.Values;
 
         /// <summary>
-        /// Subscribes the specified plugin to the specified hook
+        /// Subscribes the specified plugin to the specified hook.
+        /// If the plugin is already subscribed to the given hook and the index is >= 0,
+        /// the plugin will be moved to the specified index in the subscription list.
+        /// If the index is -1, the plugin will be appended to the end of the list.
         /// </summary>
-        /// <param name="hook"></param>
-        /// <param name="plugin"></param>
-        internal void SubscribeToHook(string hook, Plugin plugin)
+        /// <param name="hookName">The hook to subscribe to</param>
+        /// <param name="plugin">The plugin to subscribe</param>
+        /// <param name="subIndex">The index in the subscription list where the plugin should be moved to, if >= 0. Default is -1(append to the end)</param>
+        internal void SubscribeToHook(string hookName, Plugin plugin, int subIndex = -1)
         {
-            if (!loadedPlugins.ContainsKey(plugin.Name) || !plugin.IsCorePlugin && (hook.StartsWith("IOn") || hook.StartsWith("ICan")))
+            if (!loadedPlugins.ContainsKey(plugin.Name) || !plugin.IsCorePlugin && (hookName.StartsWith("IOn") || hookName.StartsWith("ICan")))
             {
                 return;
             }
 
-            HookSubscriptions sublist;
+            HookSubscriptions subscriptions;
 
             lock (hookSubscriptions)
             {
-                if (!hookSubscriptions.TryGetValue(hook, out sublist))
+                if (!hookSubscriptions.TryGetValue(hookName, out subscriptions))
                 {
-                    sublist = new HookSubscriptions();
-                    hookSubscriptions[hook] = sublist;
+                    hookSubscriptions[hookName] = subscriptions = new HookSubscriptions(GetHookTypes(hookName));
+                    /*if (subscriptions.IsStandartHook)
+                        Logger.Write(LogType.Debug, $"Hook '{hookName}' expect next types({subscriptions.ExpectedTypes.Count()}): {string.Join(", ", subscriptions.ExpectedTypes.Select(t => t.ToString()).ToArray())}");*/
                 }
             }
 
             // Avoids modifying the plugin list while iterating over it during a hook call
-            if (sublist.CallDepth > 0)
+            if (subscriptions.CallDepth > 0)
             {
-                sublist.PendingChanges.Enqueue(new SubscriptionChange(plugin, SubscriptionChangeType.Subscribe));
-                return;
+                subscriptions.PendingChanges.Enqueue(new SubscriptionChange(plugin, SubscriptionChangeType.Subscribe, subIndex));
             }
-
-            if (!sublist.Plugins.Contains(plugin))
+            else
             {
-                sublist.Plugins.Add(plugin);
+                TryAddPluginToHook(subscriptions, plugin, subIndex);
             }
-            //Logger.Write(LogType.Debug, $"Plugin {plugin.Name} is subscribing to hook '{hook}'!");
         }
 
         /// <summary>
-        /// Unsubscribes the specified plugin to the specified hook
+        /// Unsubscribes the specified plugin from the specified hook
         /// </summary>
-        /// <param name="hook"></param>
-        /// <param name="plugin"></param>
-        internal void UnsubscribeToHook(string hook, Plugin plugin)
+        /// <param name="hookName">The hook to unsubscribe from</param>
+        /// <param name="plugin">The plugin to unsubscribe</param>
+        internal void UnsubscribeFromHook(string hookName, Plugin plugin)
         {
-            if (!loadedPlugins.ContainsKey(plugin.Name) || !plugin.IsCorePlugin && (hook.StartsWith("IOn") || hook.StartsWith("ICan")))
+            if (!loadedPlugins.ContainsKey(plugin.Name) || !plugin.IsCorePlugin && (hookName.StartsWith("IOn") || hookName.StartsWith("ICan")))
             {
                 return;
             }
@@ -209,7 +268,7 @@ namespace Oxide.Core.Plugins
 
             lock (hookSubscriptions)
             {
-                if (!hookSubscriptions.TryGetValue(hook, out sublist))
+                if (!hookSubscriptions.TryGetValue(hookName, out sublist))
                 {
                     return;
                 }
@@ -223,28 +282,69 @@ namespace Oxide.Core.Plugins
             }
 
             sublist.Plugins.Remove(plugin);
-            //Logger.Write(LogType.Debug, $"Plugin {plugin.Name} is unsubscribing to hook '{hook}'!");
+            //Logger.Write(LogType.Debug, $"Plugin '{plugin.Name}' is unsubscribing from hook '{hook}'!");
+        }
+
+        /// <summary>
+        /// Adding the expected type for the hook. Works only for standard hooks(On and Can)
+        /// </summary>
+        /// <param name="hookName">The name of the hook to which it needs to be added</param>
+        /// <param name="type">The type that needs to be added</param>
+        public void AddTypeToHook(string hookName, Type type)
+        {
+            // The type to add is null or the hook is non-standard(!On and !Can)
+            if (type == null || (!hookName.StartsWith("On", StringComparison.OrdinalIgnoreCase) && !hookName.StartsWith("Can", StringComparison.OrdinalIgnoreCase)))
+            {
+                return;
+            }
+
+            // Adding type to the dictionary of Types
+            if (!expectedHookTypes.TryGetValue(type, out var hooks))
+            {
+                expectedHookTypes[type] = hooks = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            // Failed to add because it is already present in this list and no actions are needed, exiting
+            if (!hooks.Add(hookName))
+            {
+                return;
+            }
+
+            HookSubscriptions subscriptions;
+
+            lock (hookSubscriptions)
+            {
+                if (!hookSubscriptions.TryGetValue(hookName, out subscriptions))
+                {
+                    return;
+                }
+            }
+
+            // Adding a Type to an existing subscribed hook
+            if (subscriptions.IsStandartHook)
+            {
+                subscriptions.ExpectedTypes.Add(type);
+            }
         }
 
         /// <summary>
         /// Calls a hook on all plugins of this manager
         /// </summary>
-        /// <param name="hook"></param>
+        /// <param name="hookName"></param>
         /// <param name="args"></param>
         /// <returns></returns>
-        public object CallHook(string hook, params object[] args)
+        public object CallHook(string hookName, params object[] args)
         {
             HookSubscriptions subscriptions;
 
             // Locate the sublist
             lock (hookSubscriptions)
             {
-                if (!hookSubscriptions.TryGetValue(hook, out subscriptions))
+                if (!hookSubscriptions.TryGetValue(hookName, out subscriptions))
                 {
                     return null;
                 }
             }
-
 
             if (subscriptions.Plugins.Count == 0)
             {
@@ -253,38 +353,46 @@ namespace Oxide.Core.Plugins
 
             // Loop each item
             object[] values = ObjectPool.Take(subscriptions.Plugins.Count);
-            int returnCount = 0;
-            object finalValue = null;
-            Plugin finalPlugin = null;
+
+            object returnValue = null;// The value that will be returned, it will remain null if all plugins return null values
+            object lastValue = null;// The last non-null value for non-standard(!On and !Can) hooks or valid types
+            Plugin lastPlugin = null;// The last plugin with a non-null value for non-standard(!On and !Can) hooks or valid types
+            int validCount = 0;// The count of non-null values for non-standard(!On and !Can) hooks or valid types
 
             subscriptions.CallDepth++;
-
             try
             {
                 for (int i = 0; i < subscriptions.Plugins.Count; i++)
                 {
                     Plugin plugin = subscriptions.Plugins[i];
                     // Call the hook
-                    object value = plugin.CallHook(hook, args);
+                    object value = plugin.CallHook(hookName, args);
                     if (value != null)
                     {
-                        values[i] = value;
-                        finalValue = value;
-                        finalPlugin = plugin;
-                        returnCount++;
+                        returnValue = value;// Assigning the last non-null value of ANY type
+
+                        // Assigning non-null values for non-standard(!On and !Can) hooks or VALID types
+                        if (!subscriptions.IsStandartHook || subscriptions.ExpectedTypes.Contains(value.GetType()))
+                        {
+                            values[i] = value;
+                            lastValue = value;
+                            lastPlugin = plugin;
+                            validCount++;
+                        }
                     }
                 }
 
-                // Is there a return value?
-                if (returnCount == 0)
+                // Assigning the last valid value to the return value in case the last iterated plugin returns an invalid value
+                if (validCount > 0)
                 {
-                    ObjectPool.Return(values);
-                    return null;
+                    returnValue = lastValue;
                 }
 
-                if (returnCount > 1 && finalValue != null)
+                // The number of non-null values of non-standard(!On and !Can) or VALID types is greater than 0, the last hook conflict time was not found or has already passed
+                // If a hook conflict is present, it won't go away quickly, and performing constant checks for such hooks is unnecessary and causes spam in the console, especially for hooks like CanBeTargeted
+                if (validCount > 0 && (!nextHookConflictsCheckAt.TryGetValue(hookName, out float nextConflictAt) || nextConflictAt <= Interface.Oxide.Now))
                 {
-                    // Notify log of hook conflict
+                    // Perform a hook conflict check
                     hookConflicts.Clear();
                     for (int i = 0; i < subscriptions.Plugins.Count; i++)
                     {
@@ -297,25 +405,32 @@ namespace Oxide.Core.Plugins
 
                         if (value.GetType().IsValueType)
                         {
-                            if (!values[i].Equals(finalValue))
+                            if (!values[i].Equals(lastValue))
                             {
                                 hookConflicts.Add($"{plugin.Name} - {value} ({value.GetType().Name})");
                             }
                         }
                         else
                         {
-                            if (values[i] != finalValue)
+                            if (values[i] != lastValue)
                             {
                                 hookConflicts.Add($"{plugin.Name} - {value} ({value.GetType().Name})");
                             }
                         }
                     }
+
+                    // The number of conflicting values is greater than 0
                     if (hookConflicts.Count > 0)
                     {
-                        hookConflicts.Add($"{finalPlugin.Name} ({finalValue} ({finalValue.GetType().Name}))");
-                        Logger.Write(LogType.Warning, "Calling hook {0} resulted in a conflict between the following plugins: {1}", hook, string.Join(", ", hookConflicts.ToArray()));
+                        // Notify the log about it
+                        hookConflicts.Add($"{lastPlugin.Name} ({lastValue} ({lastValue.GetType().Name}))");
+                        Logger.Write(LogType.Warning, "Calling hook '{0}' resulted in a conflict between the following plugins: {1}", hookName, string.Join(", ", hookConflicts.ToArray()));
+
+                        // Setting the time for which the hook conflict check will be ignored to avoid unnecessary checks and console spam
+                        nextHookConflictsCheckAt[hookName] = Interface.Oxide.Now + 60f;
                     }
                 }
+
                 ObjectPool.Return(values);
             }
             finally
@@ -323,31 +438,24 @@ namespace Oxide.Core.Plugins
                 subscriptions.CallDepth--;
                 if (subscriptions.CallDepth == 0)
                 {
-                    ProcessHookChanges(subscriptions);
-                }
-            }
-
-            return finalValue;
-        }
-
-        private void ProcessHookChanges(HookSubscriptions subscriptions)
-        {
-            while (subscriptions.PendingChanges.Count != 0)
-            {
-                SubscriptionChange change = subscriptions.PendingChanges.Dequeue();
-
-                if (change.Change == SubscriptionChangeType.Subscribe)
-                {
-                    if (!subscriptions.Plugins.Contains(change.Plugin))
+                    // ProcessHookChanges
+                    while (subscriptions.PendingChanges.Count != 0)
                     {
-                        subscriptions.Plugins.Add(change.Plugin);
+                        SubscriptionChange change = subscriptions.PendingChanges.Dequeue();
+
+                        if (change.Change == SubscriptionChangeType.Subscribe)
+                        {
+                            TryAddPluginToHook(subscriptions, change.Plugin, change.Index);
+                        }
+                        else
+                        {
+                            subscriptions.Plugins.Remove(change.Plugin);
+                        }
                     }
                 }
-                else
-                {
-                    subscriptions.Plugins.Remove(change.Plugin);
-                }
             }
+
+            return returnValue;
         }
 
         /// <summary>
@@ -377,14 +485,65 @@ namespace Oxide.Core.Plugins
             }
 
             float now = Interface.Oxide.Now;
-            if (!lastDeprecatedWarningAt.TryGetValue(oldHook, out float lastWarningAt) || now - lastWarningAt > 3600f)
+            if (!nextDeprecatedWarningAt.TryGetValue(oldHook, out float nextWarningAt) || nextWarningAt <= now)
             {
                 // TODO: Add better handling
-                lastDeprecatedWarningAt[oldHook] = now;
-                Interface.Oxide.LogWarning($"'{subscriptions.Plugins[0].Name} v{subscriptions.Plugins[0].Version}' is using deprecated hook '{oldHook}', which will stop working on {expireDate.ToString("D")}. Please ask the author to update to '{newHook}'");
+                var plugin = subscriptions.Plugins[0];
+                Interface.Oxide.LogWarning($"'{plugin.Name} v{plugin.Version}' is using deprecated hook '{oldHook}', which will stop working on {expireDate.ToString("D")}. Please contact the author '{plugin.Author}' to update to '{newHook}'");
+
+                // Setting the time for which notifications about deprecated hooks will be ignored
+                nextDeprecatedWarningAt[oldHook] = now + 3600f;
             }
 
             return CallHook(oldHook, args);
+        }
+
+        // Retrieving saved Types from the dictionary by hook name
+        private HashSet<Type> GetHookTypes(string hookName)
+        {
+            // The hook doesn't start with On or Can, meaning it's not a standard hook, returning null
+            if (!hookName.StartsWith("On", StringComparison.OrdinalIgnoreCase) && !hookName.StartsWith("Can", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var result = new HashSet<Type>();
+
+            // The hook starts with Can, which means it's a boolean hook
+            if (hookName.StartsWith("Can", StringComparison.OrdinalIgnoreCase))
+            {
+                result.Add(typeof(bool));
+            }
+
+            foreach (var kvp in expectedHookTypes)
+            {
+                if (kvp.Value.Contains(hookName))
+                {
+                    result.Add(kvp.Key);
+                }
+            }
+            return result;
+        }
+
+        // Plugin subscription to a hook, with the option to specify the queue in the list
+        // The ability to specify the call order is mainly needed for API plugins, where hooks should be called before others, such as when a player connects
+        private void TryAddPluginToHook(HookSubscriptions subscriptions, Plugin plugin, int subIndex)
+        {
+            //Logger.Write(LogType.Debug, $"Plugin '{plugin.Name}' is subscribing to hook '{hook}'!");
+            int currentIndex = subscriptions.Plugins.IndexOf(plugin);
+            if (currentIndex == -1 || (subIndex >= 0 && subIndex != currentIndex && subscriptions.Plugins.Remove(plugin)))
+            {
+                // If the current index is -1, it means the plugin is not in the list, so we simply add it depending on the specified index
+                // Otherwise, if the subscriber has indicated a desired index(index >= 0), we move the plugin to the specified index
+                if (subIndex < 0 || subIndex >= subscriptions.Plugins.Count)
+                {
+                    subscriptions.Plugins.Add(plugin);
+                }
+                else
+                {
+                    subscriptions.Plugins.Insert(subIndex, plugin);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The **call order** of hooks in plugins and improvements in **hook conflicts**.  
In the archive, I have provided the compiled Oxide.Core and two plugins for testing.

### 1. The <ins>call order</ins> of hooks in plugins.
Previously, when plugins subscribed to a hook, they were simply **added to the end of the hook's plugin list**. For most plugins, this wasn't a problem, but there are API plugins(AdvancedStatus, ZoneManager, MonumentsWatcher, ImageLibrary, etc.) where the hook should be called before other plugins.

For example, with my **AdvancedStatus** and **WipeStatus** plugins: in the **OnPlayerConnected** hook, the AdvancedStatus plugin initializes the player so that the necessary status bars can be added. On the other hand, the WipeStatus plugin calls the API method to add a status bar for the player showing the time until the wipe.  
But in 99% of cases, WipeStatus is positioned earlier in the queue, meaning that WipeStatus receives the OnPlayerConnected hook call before AdvancedStatus, so by the time the API is called, AdvancedStatus hasn't yet initialized the player.

With the ability to specify the order of subscriptions, the AdvancedStatus plugin(and others like it) can resubscribe with the necessary index, for example **Subscribe("OnPlayerConnected", 0);**, ensuring that API plugins are the first to receive hook calls.  
**This change does not affect plugins that don't care about the order in the queue, for them, everything remains as it was.**

### 2. Improvements in <ins>hook conflicts</ins>.
**A delay has been added between hook conflict checks when a conflict occurs.**  
This was implemented for a simple reason: a hook conflict won’t resolve instantly and constantly checking for conflicts between hooks that are known to conflict adds unnecessary operations and causes console spam.  
This is especially noticeable in hooks like **CanBeTargeted** and similar hooks.

**Now, regarding hook conflicts between plugins(the changes only affect standard hooks, On and Can)**
In the proposed version. There can be multiple expected types.  For all **Can** hooks, a bool type is automatically added as the expected type. For **On** hooks, no expected type is set, allowing any return type without causing a conflict.  
For existing **On(non-object)** hooks, default expected types have been added. However, it is also possible to add custom expected types for hooks.  
With this implementation, a hook conflict occurs only when there are differing expected type values.

Informally, there are 3 types of hooks, all of which expect **null or non-null** values:
1. **Can** - In 99.99% of cases, it expects a **non-null bool** value. However, there are exceptions, such as the **CanAcceptItem** hook, which expects **ItemContainer.CanAcceptResult**.  
2. **On(object)** - These hooks don't care about the value or type of value they get, they only distinguish between **null or non-null**.
Conflicts most often occur with these hooks. In the current version, it is not taken into account that these hooks do not care about the type or the non-null value returned to them.
Since the type doesn't matter for non-null values, different developers may return **true** or **false**, and this causes server console spam when conflicting plugins are installed. For many plugins, there’s no real difference between returning **false** or **true** for non-null values, but in my plugins, there are cases where the returned value is used elsewhere, and returning **true as negation** confuses me. Therefore, for object hooks, I prefer returning **false** for non-null values.  
3. **On(non-object)** - These are similar to object **On(object)** hooks, but for these, **the specific type and value of a non-null return matter**. There are fewer of these hooks than object ones, and they’re essentially exceptions among On hooks.
In essence, for these hooks, returning **non-null values of any other type is treated the same as if they had returned null**. In the current version, if plugin **ONE** returns **any non-null value** and plugin **TWO** returns a **non-null expected type**, a conflict message will appear, and **the last value requested by the hook will be returned**(this can be either an expected type or a non-expected type), even though plugin **TWO’s** value is the expected and correct one.
**In the proposed version, the last non-null value will be returned, or the last non-null value of the correct type, without causing a conflict, unless different expected types are present.**