### PR TITLE
Optimize Formatter for 90% less memory usage and 15-30% faster execution

### DIFF
--- a/src/Libraries/Covalence/Formatter.cs
+++ b/src/Libraries/Covalence/Formatter.cs
@@ -21,28 +21,48 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
+using Oxide.Pooling;
 
 namespace Oxide.Core.Libraries.Covalence
 {
-    public class Element
+    public class Element : Formatter.Poolable<Element>
     {
         public ElementType Type;
         public object Val;
         public List<Element> Body = new List<Element>();
 
-        private Element(ElementType type, object val)
+        public Element() {}
+
+        public Element(ElementType type, object val)
         {
             Type = type;
             Val = val;
         }
 
-        public static Element String(object s) => new Element(ElementType.String, s);
+        private static Element Get(ElementType type, object val, bool shouldPool)
+        {
+            if (!shouldPool)
+                return new Element(type, val);
 
-        public static Element Tag(ElementType type) => new Element(type, null);
+            Element e = TakeFromPool();
+            e.Type = type;
+            e.Val = val;
+            return e;
+        }
 
-        public static Element ParamTag(ElementType type, object val) => new Element(type, val);
+        protected override void Reset()
+        {
+            Type = default;
+            Val = default;
+            ReturnToPool(Body);
+        }
+
+        public static Element String(object s, bool shouldPool = false) => Element.Get(ElementType.String, s, shouldPool);
+
+        public static Element Tag(ElementType type, bool shouldPool = false) => Element.Get(type, null, shouldPool);
+
+        public static Element ParamTag(ElementType type, object val, bool shouldPool = false) => Element.Get(type, val, shouldPool);
     }
 
     public enum ElementType { String, Bold, Italic, Color, Size }
@@ -75,8 +95,65 @@ namespace Oxide.Core.Libraries.Covalence
             ["yellow"] = "ffff00"
         };
 
-        private class Token
-        { public TokenType Type; public object Val; public string Pattern; }
+        private static readonly Tag emptyTag = new Tag(string.Empty, string.Empty);
+        private static readonly Tag boldTag = new Tag("<b>", "</b>");
+        private static readonly Tag italicTag = new Tag("<i>", "</i>");
+
+        private static readonly Dictionary<ElementType, Func<object, Tag>> plainTextTranslations =
+            new Dictionary<ElementType, Func<object, Tag>>();
+
+        private static readonly Dictionary<ElementType, Func<object, Tag>> unityTranslations =
+            new Dictionary<ElementType, Func<object, Tag>>
+            {
+                [ElementType.Bold] = _ => boldTag,
+                [ElementType.Italic] = _ => italicTag,
+                [ElementType.Color] = c => new Tag($"<color=#{c}>", "</color>"),
+                [ElementType.Size] = s => new Tag($"<size={s}>", "</size>")
+            };
+
+        private static readonly new Dictionary<ElementType, Func<object, Tag>> rustLegacyTranslations =
+            new Dictionary<ElementType, Func<object, Tag>>
+            {
+                [ElementType.Color] = c => new Tag($"[color #{RGBAtoRGB(c)}]", "[color #ffffff]")
+            };
+
+        private static readonly Dictionary<ElementType, Func<object, Tag>> rokAnd7DTDTranslations =
+            new Dictionary<ElementType, Func<object, Tag>>
+            {
+                [ElementType.Color] = c => new Tag($"[{RGBAtoRGB(c)}]", "[e7e7e7]")
+            };
+
+        private static readonly Dictionary<ElementType, Func<object, Tag>> terrariaTranslations =
+            new Dictionary<ElementType, Func<object, Tag>>
+            {
+                [ElementType.Color] = c => new Tag($"[c/{RGBAtoRGB(c)}:", "]")
+            };
+
+        private static readonly IPoolProvider<StringBuilder> stringPool = Interface.Oxide.PoolFactory.GetProvider<StringBuilder>();
+
+        private class Token : Poolable<Token>
+        {
+            public TokenType Type;
+            public object Val;
+            public string Pattern;
+            private static readonly Stack<Token> pool = new Stack<Token>();
+
+            public static Token TakeFromPool(TokenType type, object val, string pattern)
+            {
+                Token t = TakeFromPool();
+                t.Type = type;
+                t.Val = val;
+                t.Pattern = pattern;
+                return t;
+            }
+
+            protected override void Reset()
+            {
+                Type = default;
+                Val = default;
+                Pattern = default;
+            }
+        }
 
         private enum TokenType
         { String, Bold, Italic, Color, Size, CloseBold, CloseItalic, CloseColor, CloseSize }
@@ -90,15 +167,25 @@ namespace Oxide.Core.Libraries.Covalence
             [ElementType.Size] = TokenType.CloseSize
         };
 
-        private class Lexer
+        private class Lexer : Poolable<Lexer>
         {
-            private delegate State State();
+            private enum StateType
+            {
+                Str,
+                Tag,
+                CloseTag,
+                EndTag,
+                ParamTag
+            }
 
-            private string text;
+            private List<Token> tokens = new List<Token>();
             private int patternStart;
             private int tokenStart;
             private int position;
-            private List<Token> tokens = new List<Token>();
+            private string text;
+            private StateType state;
+            private TokenType currentTokenType;
+            private Func<string, object> currentParser;
 
             private char Current() => text[position];
 
@@ -112,18 +199,13 @@ namespace Oxide.Core.Libraries.Covalence
                 StartNewToken();
             }
 
-            private void Reset() => tokenStart = patternStart;
+            private void ResetTokenStart() => tokenStart = patternStart;
 
             private string Token() => text.Substring(tokenStart, position - tokenStart);
 
             private void Add(TokenType type, object val = null)
             {
-                Token t = new Token
-                {
-                    Type = type,
-                    Val = val,
-                    Pattern = text.Substring(patternStart, position - patternStart)
-                };
+                Token t = Formatter.Token.TakeFromPool(type, val, text.Substring(patternStart, position - patternStart));
                 tokens.Add(t);
             }
 
@@ -140,8 +222,20 @@ namespace Oxide.Core.Libraries.Covalence
                 tokenStart = ts;
             }
 
-            private static bool IsValidColorCode(string val) => (val.Length == 6 || val.Length == 8)
-                && val.All(c => c >= '0' && c <= '9' || c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F');
+            private static bool IsValidColorCode(string val)
+            {
+                if (val.Length != 6 && val.Length != 8)
+                    return false;
+
+                for (int i = 0; i < val.Length; i++)
+                {
+                    char c = val[i];
+                    if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')))
+                        return false;
+                }
+
+                return true;
+            }
 
             private static object ParseColor(string val)
             {
@@ -164,205 +258,330 @@ namespace Oxide.Core.Libraries.Covalence
             }
 
             // End of tag (]), transition back to Str
-            private State EndTag(TokenType t)
+            private void EndTag()
             {
-                Next();
-                return () =>
+                if (Current() == ']')
                 {
-                    char ch = Current();
-                    if (ch == ']')
-                    {
-                        Next();
-                        Add(t);
-                        StartNewPattern();
-                        return Str;
-                    }
-                    Reset();
-                    return Str;
-                };
+                    Next();
+                    Add(currentTokenType);
+                    StartNewPattern();
+                    state = StateType.Str;
+                }
+                else
+                {
+                    ResetTokenStart();
+                    state = StateType.Str;
+                }
             }
 
             // Start of param tag ([# or [+), read and parse param
-            private State ParamTag(TokenType t, Func<string, object> parse)
+            private void ParamTag()
             {
-                Next();
-                StartNewToken();
-                State s = null;
-                s = () =>
+                if (Current() != ']')
                 {
-                    if (Current() != ']')
-                    {
-                        Next();
-                        return s;
-                    }
-                    object parsed = parse(Token());
+                    Next();
+                }
+                else
+                {
+                    object parsed = currentParser(Token());
                     if (parsed == null)
                     {
-                        Reset();
-                        return Str;
+                        ResetTokenStart();
+                        state = StateType.Str;
                     }
-                    Next();
-                    Add(t, parsed);
-                    StartNewPattern();
-                    return Str;
-                };
-                return s;
+                    else
+                    {
+                        Next();
+                        Add(currentTokenType, parsed);
+                        StartNewPattern();
+                        state = StateType.Str;
+                    }
+                }
             }
 
             // Start of close tag ([/), trying to identify close tag
-            private State CloseTag()
+            private void CloseTag()
             {
                 switch (Current())
                 {
                     case 'b':
-                        return EndTag(TokenType.CloseBold);
+                        currentTokenType = TokenType.CloseBold;
+                        Next();
+                        state = StateType.EndTag;
+                        break;
 
                     case 'i':
-                        return EndTag(TokenType.CloseItalic);
+                        currentTokenType = TokenType.CloseItalic;
+                        Next();
+                        state = StateType.EndTag;
+                        break;
 
                     case '#':
-                        return EndTag(TokenType.CloseColor);
+                        currentTokenType = TokenType.CloseColor;
+                        Next();
+                        state = StateType.EndTag;
+                        break;
 
                     case '+':
-                        return EndTag(TokenType.CloseSize);
+                        currentTokenType = TokenType.CloseSize;
+                        Next();
+                        state = StateType.EndTag;
+                        break;
 
                     default:
-                        Reset();
-                        return Str;
+                        ResetTokenStart();
+                        state = StateType.Str;
+                        break;
                 }
             }
 
             // Start of tag ([), trying to identify tag
-            private State Tag()
+            private void Tag()
             {
                 switch (Current())
                 {
                     case 'b':
-                        return EndTag(TokenType.Bold);
+                        currentTokenType = TokenType.Bold;
+                        Next();
+                        state = StateType.EndTag;
+                        break;
 
                     case 'i':
-                        return EndTag(TokenType.Italic);
+                        currentTokenType = TokenType.Italic;
+                        Next();
+                        state = StateType.EndTag;
+                        break;
 
                     case '#':
-                        return ParamTag(TokenType.Color, ParseColor);
+                        currentTokenType = TokenType.Color;
+                        currentParser = ParseColor;
+                        Next();
+                        StartNewToken();
+                        state = StateType.ParamTag;
+                        break;
 
                     case '+':
-                        return ParamTag(TokenType.Size, ParseSize);
+                        currentTokenType = TokenType.Size;
+                        currentParser = ParseSize;
+                        Next();
+                        StartNewToken();
+                        state = StateType.ParamTag;
+                        break;
 
                     case '/':
                         Next();
-                        return CloseTag;
+                        state = StateType.CloseTag;
+                        break;
 
                     default:
-                        Reset();
-                        return Str;
+                        ResetTokenStart();
+                        state = StateType.Str;
+                        break;
                 }
             }
 
             // Any string, trying to find a tag with ([)
-            private State Str()
+            private void Str()
             {
                 if (Current() == '[')
                 {
                     WritePatternString();
                     StartNewPattern();
                     Next();
-                    return Tag;
+                    state = StateType.Tag;
                 }
-                Next();
-                return Str;
+                else
+                {
+                    Next();
+                }
             }
 
             public static List<Token> Lex(string text)
             {
+                Lexer lexer = new Lexer();
+                return lexer.TokenizeText(text);
+            }
+
+            public List<Token> TokenizeText(string text)
+            {
                 // A pattern is the full pattern of a token, e.g. [#foo] instead of just foo as token
                 // When we reach eof or an error we want to default to using a string as token
                 // To accomplish this, we need the full pattern instead of just the token
-                Lexer l = new Lexer { text = text };
+                this.text = text;
 
-                // Run the state machine until EOF
-                State state = l.Str;
-                while (l.position < l.text.Length)
+                while (position < text.Length)
                 {
-                    // Each function represents a state. Each state returns a new state
-                    state = state();
+                    // Process the current character based on the current state
+                    switch (state)
+                    {
+                        case StateType.Str:
+                            Str();
+                            break;
+
+                        case StateType.Tag:
+                            Tag();
+                            break;
+
+                        case StateType.CloseTag:
+                            CloseTag();
+                            break;
+
+                        case StateType.EndTag:
+                            EndTag();
+                            break;
+
+                        case StateType.ParamTag:
+                            ParamTag();
+                            break;
+                    }
                 }
+
                 // Flush leftover pattern
-                l.WritePatternString();
-                return l.tokens;
+                WritePatternString();
+                return tokens;
+            }
+
+            protected override void Reset()
+            {
+                text = default;
+                patternStart = default;
+                tokenStart = default;
+                position = default;
+                Formatter.Token.ReturnToPool(tokens);
+                currentTokenType = default;
+                currentParser = default;
+                state = StateType.Str;
             }
         }
 
-        private class Entry
+        private class Entry : Poolable<Entry>
         {
             public string Pattern;
             public Element Element;
 
-            public Entry(string pattern, Element e)
+            static public Entry TakeFromPool(string pattern, Element element)
             {
-                Pattern = pattern;
-                Element = e;
+                Entry e = TakeFromPool();
+                e.Pattern = pattern;
+                e.Element = element;
+                return e;
+            }
+
+            protected override void Reset()
+            {
+                Pattern = default;
+                Element = default;
             }
         }
 
-        private static List<Element> Parse(List<Token> tokens)
+        private class ElementTreeBuilder : Poolable<ElementTreeBuilder>
         {
-            int i = 0;
-            Stack<Entry> s = new Stack<Entry>();
-            s.Push(new Entry(null, Element.Tag(ElementType.String)));
-            while (i < tokens.Count)
+            private readonly Stack<Entry> entries = new Stack<Entry>();
+            public bool shouldPoolElements;
+
+            public Element ProcessTokens(List<Token> tokens)
             {
-                Token t = tokens[i++];
-                Action<Element> push = el => s.Push(new Entry(t.Pattern, el));
-                Element e = s.Peek().Element;
-                if (t.Type == closeTags[e.Type])
+                int i = 0;
+                entries.Clear();
+                entries.Push(Entry.TakeFromPool(null, Element.Tag(ElementType.String, shouldPoolElements)));
+                while (i < tokens.Count)
                 {
-                    // Last tag was closed, pop tag and add to parent
-                    s.Pop();
-                    s.Peek().Element.Body.Add(e);
-                    continue;
+                    Token t = tokens[i++];
+                    Element e = entries.Peek().Element;
+                    if (t.Type == closeTags[e.Type])
+                    {
+                        // Last tag was closed, pop tag and add to parent
+                        entries.Pop();
+                        entries.Peek().Element.Body.Add(e);
+                        continue;
+                    }
+
+                    // open new tags on bold, italic, color & size.
+                    // Add strings and invalid tags as strings to body of current tag
+                    switch (t.Type)
+                    {
+                        case TokenType.String:
+                            e.Body.Add(Element.String(t.Val, shouldPoolElements));
+                            break;
+
+                        case TokenType.Bold:
+                            entries.Push(Entry.TakeFromPool(t.Pattern,
+                                Element.Tag(ElementType.Bold, shouldPoolElements)));
+                            break;
+
+                        case TokenType.Italic:
+                            entries.Push(Entry.TakeFromPool(t.Pattern,
+                                Element.Tag(ElementType.Italic, shouldPoolElements)));
+                            break;
+
+                        case TokenType.Color:
+                            entries.Push(Entry.TakeFromPool(t.Pattern,
+                                Element.ParamTag(ElementType.Color, t.Val, shouldPoolElements)));
+                            break;
+
+                        case TokenType.Size:
+                            entries.Push(Entry.TakeFromPool(t.Pattern,
+                                Element.ParamTag(ElementType.Size, t.Val, shouldPoolElements)));
+                            break;
+
+                        default:
+                            e.Body.Add(Element.String(t.Pattern, shouldPoolElements));
+                            break;
+                    }
                 }
-                // open new tags on bold, italic, color & size.
-                // Add strings and invalid tags as strings to body of current tag
-                switch (t.Type)
+
+                // Stringify all tags that weren't closed at EOF
+                while (entries.Count > 1)
                 {
-                    case TokenType.String:
-                        e.Body.Add(Element.String(t.Val));
-                        break;
-
-                    case TokenType.Bold:
-                        push(Element.Tag(ElementType.Bold));
-                        break;
-
-                    case TokenType.Italic:
-                        push(Element.Tag(ElementType.Italic));
-                        break;
-
-                    case TokenType.Color:
-                        push(Element.ParamTag(ElementType.Color, t.Val));
-                        break;
-
-                    case TokenType.Size:
-                        push(Element.ParamTag(ElementType.Size, t.Val));
-                        break;
-
-                    default:
-                        e.Body.Add(Element.String(t.Pattern));
-                        break;
+                    Entry e = entries.Pop();
+                    List<Element> body = entries.Peek().Element.Body;
+                    body.Add(Element.String(e.Pattern));
+                    body.AddRange(e.Element.Body);
+                    Entry.ReturnToPool(e);
                 }
+
+                Entry lastEntry = entries.Pop();
+                Element element = lastEntry.Element;
+                Entry.ReturnToPool(lastEntry);
+                return element;
             }
-            // Stringify all tags that weren't closed at EOF
-            while (s.Count > 1)
+
+            protected override void Reset()
             {
-                Entry e = s.Pop();
-                List<Element> body = s.Peek().Element.Body;
-                body.Add(Element.String(e.Pattern));
-                body.AddRange(e.Element.Body);
+                shouldPoolElements = default;
+                while (entries.Count > 0)
+                    Entry.ReturnToPool(entries.Pop());
             }
-            return s.Pop().Element.Body;
         }
 
-        public static List<Element> Parse(string text) => Parse(Lexer.Lex(text));
+        public static List<Element> Parse(string text) => ParseText(text, false).Body;
+
+        private static Element ParseText(string text, bool shouldPoolElements = true)
+        {
+            Lexer lexer = Lexer.TakeFromPool();
+            try
+            {
+                return ProcessTokens(lexer.TokenizeText(text), shouldPoolElements);
+            }
+            finally
+            {
+                Lexer.ReturnToPool(lexer);
+            }
+        }
+
+        private static Element ProcessTokens(List<Token> tokens, bool shouldPoolElements)
+        {
+            ElementTreeBuilder elementTreeBuilder = ElementTreeBuilder.TakeFromPool();
+            try
+            {
+                elementTreeBuilder.shouldPoolElements = shouldPoolElements;
+                return elementTreeBuilder.ProcessTokens(tokens);
+            }
+            finally
+            {
+                ElementTreeBuilder.ReturnToPool(elementTreeBuilder);
+            }
+        }
 
         private class Tag
         {
@@ -378,16 +597,29 @@ namespace Oxide.Core.Libraries.Covalence
 
         private static Tag Translation(Element e, Dictionary<ElementType, Func<object, Tag>> translations)
         {
-            return translations.TryGetValue(e.Type, out Func<object, Tag> parse) ? parse(e.Val) : new Tag("", "");
+            return translations.TryGetValue(e.Type, out Func<object, Tag> parse) ? parse(e.Val) : emptyTag;
         }
 
         private static string ToTreeFormat(List<Element> tree, Dictionary<ElementType, Func<object, Tag>> translations)
+        {
+            StringBuilder sb = stringPool.Take();
+            try
+            {
+                AppendTreeFormat(tree, translations, sb);
+                return sb.ToString();
+            }
+            finally
+            {
+                stringPool.Return(sb);
+            }
+        }
+
+        private static void AppendTreeFormat(List<Element> tree, Dictionary<ElementType, Func<object, Formatter.Tag>> translations, StringBuilder sb)
         {
             // translation(string) 	= string_value
             // translation(tree) 	= open_tag_translation
             //                      + translation(child_1) + translation(child_2) + ... + translation(child_n)
             //                      + close_tag_translation
-            StringBuilder sb = new StringBuilder();
             foreach (Element e in tree)
             {
                 if (e.Type == ElementType.String)
@@ -397,39 +629,78 @@ namespace Oxide.Core.Libraries.Covalence
                 }
                 Tag tag = Translation(e, translations);
                 sb.Append(tag.Open);
-                sb.Append(ToTreeFormat(e.Body, translations));
+                AppendTreeFormat(e.Body, translations, sb);
                 sb.Append(tag.Close);
             }
-            return sb.ToString();
         }
 
-        private static string ToTreeFormat(string text, Dictionary<ElementType, Func<object, Tag>> translations) => ToTreeFormat(Parse(text), translations);
+        private static string ToTreeFormat(string text, Dictionary<ElementType, Func<object, Tag>> translations)
+        {
+            Element element = ParseText(text);
+            try
+            {
+                return ToTreeFormat(element.Body, translations);
+            }
+            finally
+            {
+                Element.ReturnToPool(element);
+            }
+        }
 
         private static string RGBAtoRGB(object rgba) => rgba.ToString().Substring(0, 6);
 
-        public static string ToPlaintext(string text) => ToTreeFormat(text, new Dictionary<ElementType, Func<object, Tag>>());
+        public static string ToPlaintext(string text) => ToTreeFormat(text, plainTextTranslations);
 
-        public static string ToUnity(string text) => ToTreeFormat(text, new Dictionary<ElementType, Func<object, Tag>>
-        {
-            [ElementType.Bold] = _ => new Tag("<b>", "</b>"),
-            [ElementType.Italic] = _ => new Tag("<i>", "</i>"),
-            [ElementType.Color] = c => new Tag($"<color=#{c}>", "</color>"),
-            [ElementType.Size] = s => new Tag($"<size={s}>", "</size>")
-        });
+        public static string ToUnity(string text) => ToTreeFormat(text, unityTranslations);
 
-        public static string ToRustLegacy(string text) => ToTreeFormat(text, new Dictionary<ElementType, Func<object, Tag>>
-        {
-            [ElementType.Color] = c => new Tag($"[color #{RGBAtoRGB(c)}]", "[color #ffffff]")
-        });
+        public static string ToRustLegacy(string text) => ToTreeFormat(text, rustLegacyTranslations);
 
-        public static string ToRoKAnd7DTD(string text) => ToTreeFormat(text, new Dictionary<ElementType, Func<object, Tag>>
-        {
-            [ElementType.Color] = c => new Tag($"[{RGBAtoRGB(c)}]", "[e7e7e7]")
-        });
+        public static string ToRoKAnd7DTD(string text) => ToTreeFormat(text, rokAnd7DTDTranslations);
 
-        public static string ToTerraria(string text) => ToTreeFormat(text, new Dictionary<ElementType, Func<object, Tag>>
+        public static string ToTerraria(string text) => ToTreeFormat(text, terrariaTranslations);
+
+        public abstract class Poolable<T> where T : Poolable<T>, new()
         {
-            [ElementType.Color] = c => new Tag($"[c/{RGBAtoRGB(c)}:", "]")
-        });
+            private static readonly Stack<T> _pool = new Stack<T>();
+            private static readonly object _poolLock = new object();
+
+            protected bool isFromPool { get; private set; }
+
+            public static T TakeFromPool()
+            {
+                T item;
+                lock (_poolLock)
+                {
+                    item = _pool.Count > 0 ? _pool.Pop() : new T();
+                }
+                item.isFromPool = true;
+                return item;
+            }
+
+            public static void ReturnToPool(T obj)
+            {
+                if (obj == null || !obj.isFromPool)
+                    return;
+
+                obj.Reset();
+                lock (_poolLock)
+                {
+                    _pool.Push(obj);
+                }
+            }
+
+            public static void ReturnToPool(List<T> objs)
+            {
+                if (objs == null)
+                    return;
+
+                for (int i = 0; i < objs.Count; i++)
+                    ReturnToPool(objs[i]);
+
+                objs.Clear();
+            }
+
+            protected abstract void Reset();
+        }
     }
 }


### PR DESCRIPTION
I've optimized the Formatter class to significantly improve its memory efficiency and performance

### Main Improvements
1. Added Object Pooling: Implemented a custom `Poolable<T>` system that recycles `Element`, `Token`, `Lexer`, `Entry`, and `ElementTreeBuilder` objects
2. Replaced the delegate-based `Lexer` state machine with a more efficient enum-based implementation
3. Optimized String Handling: Implemented `StringBuilder` pooling within `ToTreeFormat()`
4. Cached Common Objects: Created static cached instances for frequently used objects like translation dictionaries and common tags
5. Maintained API Compatibility: Preserved the original public APIs so third-parties wouldn't need modifications

### Benchmark Results

Using [this crude benchmark script](https://gist.github.com/ThePaperPlate/35990b6dc74666d3080ff0cfaf4c804f) on both the original and optimized versions:

**Before vs After (100 iterations on 2053 test inputs):**

#### Execution Time (lower is better)
![Time Comparison](https://quickchart.io/chart?c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22ToPlaintext%22%2C%22ToUnity%22%2C%22ToRustLegacy%22%2C%22ToRoKAnd7DTD%22%2C%22ToTerraria%22%2C%22Parse%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Original%20(ms)%22%2C%22backgroundColor%22%3A%22rgba(255%2C99%2C132%2C0.5)%22%2C%22data%22%3A%5B3.41%2C2.34%2C1.85%2C1.85%2C1.84%2C1.46%5D%7D%2C%7B%22label%22%3A%22Optimized%20(ms)%22%2C%22backgroundColor%22%3A%22rgba(54%2C162%2C235%2C0.5)%22%2C%22data%22%3A%5B2.91%2C1.61%2C1.51%2C1.51%2C1.51%2C1.19%5D%7D%5D%7D%7D)

#### Memory Usage (lower is better)
![Memory Comparison](https://quickchart.io/chart?c=%7B%22type%22%3A%22bar%22%2C%22data%22%3A%7B%22labels%22%3A%5B%22ToPlaintext%22%2C%22ToUnity%22%2C%22ToRustLegacy%22%2C%22ToRoKAnd7DTD%22%2C%22ToTerraria%22%2C%22Parse%22%5D%2C%22datasets%22%3A%5B%7B%22label%22%3A%22Original%20(MB)%22%2C%22backgroundColor%22%3A%22rgba(255%2C99%2C132%2C0.5)%22%2C%22data%22%3A%5B1628.16%2C1802.24%2C1699.84%2C1689.6%2C1679.36%2C1392.64%5D%7D%2C%7B%22label%22%3A%22Optimized%20(MB)%22%2C%22backgroundColor%22%3A%22rgba(54%2C162%2C235%2C0.5)%22%2C%22data%22%3A%5B158.23%2C185.4%2C178.11%2C173.36%2C173.28%2C254.18%5D%7D%5D%7D%2C%22options%22%3A%7B%22scales%22%3A%7B%22y%22%3A%7B%22beginAtZero%22%3Atrue%7D%7D%7D%7D)

| Formatter | Original Time | Optimized Time | Time Improvement | Original Memory | Optimized Memory | Memory Reduction |
|-----------|---------------|----------------|------------------|-----------------|------------------|------------------|
| ToPlaintext | 3.41 ms | 2.91 ms | 14.7% faster | 1.59 GB | 158.23 MB | 90.3% less |
| ToUnity | 2.34 ms | 1.61 ms | 31.2% faster | 1.76 GB | 185.40 MB | 89.7% less |
| ToRustLegacy | 1.85 ms | 1.51 ms | 18.4% faster | 1.66 GB | 178.11 MB | 89.5% less |
| ToRoKAnd7DTD | 1.85 ms | 1.51 ms | 18.4% faster | 1.65 GB | 173.36 MB | 89.7% less |
| ToTerraria | 1.84 ms | 1.51 ms | 17.9% faster | 1.64 GB | 173.28 MB | 89.7% less |
| Parse | 1.46 ms | 1.19 ms | 18.5% faster | 1.36 GB | 254.18 MB | 81.7% less |
