### PR TITLE
Simple change to allow server startup on Linux with linked plugins

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -7,4 +7,8 @@
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
+  <packageSources>
+    <add key="Oxide" value="https://www.myget.org/f/oxide/api/v3/index.json" />
+    <add key="OxideTemp" value="https://www.myget.org/f/oxidetemp/api/v3/index.json" />
+  </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -7,8 +7,4 @@
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
-  <packageSources>
-    <add key="Oxide" value="https://www.myget.org/f/oxide/api/v3/index.json" />
-    <add key="OxideTemp" value="https://www.myget.org/f/oxidetemp/api/v3/index.json" />
-  </packageSources>
 </configuration>

--- a/src/Plugins/Watchers/FSWatcher.cs
+++ b/src/Plugins/Watchers/FSWatcher.cs
@@ -85,7 +85,7 @@ namespace Oxide.Core.Plugins.Watchers
 #endif
         private void LoadWatcherSymlink(string path)
         {
-            StringBuilder str = StringPool.Take();
+            StringBuilder str = new StringBuilder() { Capacity = 256 };
             try
             {
                 int count = Syscall.readlink(path, str);
@@ -104,7 +104,7 @@ namespace Oxide.Core.Plugins.Watchers
                     }
                 }
 
-                string realPath = str.ToString(0, count);
+                string realPath = str.ToString();
                 string realDirName = Path.GetDirectoryName(realPath);
                 string realFileName = Path.GetFileName(realPath);
 
@@ -124,11 +124,6 @@ namespace Oxide.Core.Plugins.Watchers
             {
                 Interface.Oxide.LogException(path, e);
             }
-            finally
-            {
-                StringPool.Return(str);
-            }
-
         }
 
         /// <summary>

--- a/src/Plugins/Watchers/FSWatcher.cs
+++ b/src/Plugins/Watchers/FSWatcher.cs
@@ -120,6 +120,10 @@ namespace Oxide.Core.Plugins.Watchers
                 watcher.IncludeSubdirectories = false;
                 watcher.EnableRaisingEvents = true;
             }
+            catch (Exception e)
+            {
+                Interface.Oxide.LogException(path, e);
+            }
             finally
             {
                 StringPool.Return(str);


### PR DESCRIPTION
On my home server running AlmaLinux 8.X, I currently have 147 plugins, all linked to local repos or download folders.  Prior to this change, the server would stall during startup when reading linked plugins.  It does not consistently happen with the same plugins or target folders.  But, it fails to continue to load after encountering the first failure.

```
ArgumentOutOfRangeException: Index and length must refer to a location within the string.
Parameter name: length
  at System.Text.StringBuilder.ToString (System.Int32 startIndex, System.Int32 length) [0x00049] in <f98723dd4586469db5213ec59da723ca>:0
  at Oxide.Core.Plugins.Watchers.FSWatcher.LoadWatcherSymlink (System.String path) [0x00043] in <8cb2d664f1574f2b96d53f1c1869d96a>:0
  at Oxide.Core.Plugins.Watchers.FSWatcher..ctor (System.String directory, System.String filter) [0x000a2] in <8cb2d664f1574f2b96d53f1c1869d96a>:0
  at Oxide.Plugins.CSharpExtension.LoadPluginWatchers (System.String pluginDirectory) [0x00000] in <42f9bedc659b4f4786eb778d3cd58968>:0
  at Oxide.Core.OxideMod.Load () [0x00599] in <8cb2d664f1574f2b96d53f1c1869d96a>:0
  at Oxide.Core.Interface.Initialize () [0x0001d] in <8cb2d664f1574f2b96d53f1c1869d96a>:0
  at Bootstrap.Init_Tier0 () [0x0010d] in <e7a4f6daf46144f0a1cd5df4f4228a12>:0
  at Bootstrap+<Start>d__17.MoveNext () [0x003bc] in <e7a4f6daf46144f0a1cd5df4f4228a12>:0
  at UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) [0x00026] in <470ec865e9cd405cbc45cdbc22bb3c0c>:0
```
Adding this catch not only allows server startup to continue, but once startup is complete, all plugins have been loaded.  This is not a fix for the actual cause of the failed call to readlink, but the results are favorable.

Note that this problem has been occurring for me for over a year, forcing me to stop using links and instead copying and updating the files externally to avoid the problem.  This worked for years before, i.e. since I started writing plugins.