### PR TITLE
Fix symlink reading

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -7,4 +7,8 @@
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
+  <packageSources>
+    <add key="Oxide" value="https://www.myget.org/f/oxide/api/v3/index.json" />
+    <add key="OxideTemp" value="https://www.myget.org/f/oxidetemp/api/v3/index.json" />
+  </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -7,8 +7,4 @@
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
-  <packageSources>
-    <add key="Oxide" value="https://www.myget.org/f/oxide/api/v3/index.json" />
-    <add key="OxideTemp" value="https://www.myget.org/f/oxidetemp/api/v3/index.json" />
-  </packageSources>
 </configuration>

--- a/src/Plugins/Watchers/FSWatcher.cs
+++ b/src/Plugins/Watchers/FSWatcher.cs
@@ -85,7 +85,7 @@ namespace Oxide.Core.Plugins.Watchers
 #endif
         private void LoadWatcherSymlink(string path)
         {
-            StringBuilder str = StringPool.Take();
+            StringBuilder str = new StringBuilder() { Capacity = 256 };
             try
             {
                 int count = Syscall.readlink(path, str);
@@ -104,7 +104,7 @@ namespace Oxide.Core.Plugins.Watchers
                     }
                 }
 
-                string realPath = str.ToString(0, count);
+                string realPath = str.ToString();
                 string realDirName = Path.GetDirectoryName(realPath);
                 string realFileName = Path.GetFileName(realPath);
 
@@ -124,11 +124,6 @@ namespace Oxide.Core.Plugins.Watchers
             {
                 Interface.Oxide.LogException(path, e);
             }
-            finally
-            {
-                StringPool.Return(str);
-            }
-
         }
 
         /// <summary>

--- a/src/Plugins/Watchers/FSWatcher.cs
+++ b/src/Plugins/Watchers/FSWatcher.cs
@@ -85,7 +85,8 @@ namespace Oxide.Core.Plugins.Watchers
 #endif
         private void LoadWatcherSymlink(string path)
         {
-            StringBuilder str = new StringBuilder() { Capacity = 256 };
+            StringBuilder str = StringPool.Take();
+            str.Capacity = 4096;
             try
             {
                 int count = Syscall.readlink(path, str);
@@ -104,7 +105,7 @@ namespace Oxide.Core.Plugins.Watchers
                     }
                 }
 
-                string realPath = str.ToString();
+                string realPath = str.ToString(0, count);
                 string realDirName = Path.GetDirectoryName(realPath);
                 string realFileName = Path.GetFileName(realPath);
 
@@ -120,9 +121,9 @@ namespace Oxide.Core.Plugins.Watchers
                 watcher.IncludeSubdirectories = false;
                 watcher.EnableRaisingEvents = true;
             }
-            catch (Exception e)
+            finally
             {
-                Interface.Oxide.LogException(path, e);
+                StringPool.Return(str);
             }
         }
 

--- a/src/Plugins/Watchers/FSWatcher.cs
+++ b/src/Plugins/Watchers/FSWatcher.cs
@@ -120,6 +120,10 @@ namespace Oxide.Core.Plugins.Watchers
                 watcher.IncludeSubdirectories = false;
                 watcher.EnableRaisingEvents = true;
             }
+            catch (Exception e)
+            {
+                Interface.Oxide.LogException(path, e);
+            }
             finally
             {
                 StringPool.Return(str);


### PR DESCRIPTION
StringPool.Take was always returning a size/count of 16.  So, any symlink target longer than 16 characters was being truncated.  Hard-coded to 256 as a max path, allowing the plugin watcher to work for symlinks.

This 256 character limit might be a problem for some, but 16 is generally too small.  In other words, there is probably a better way to handle this.

Also added a catch to the try when reading symlinks.  Without this, it was blocking server load at the first error encountered randomly with different linked plugins.

Together, these allow my server to load, with all linked plugins, and changes made to the plugins cause immediate reload of the plugin as with non-linked plugins.