### PR TITLE
Fix recursive parent permission lookup

### DIFF
--- a/src/Libraries/Permission.cs
+++ b/src/Libraries/Permission.cs
@@ -604,7 +604,7 @@ namespace Oxide.Core.Libraries
 
             if (parents)
             {
-                permissions.UnionWith(GetGroupPermissions(groupData.ParentGroup));
+                permissions.UnionWith(GetGroupPermissions(groupData.ParentGroup, true));
             }
 
             return permissions.ToArray();


### PR DESCRIPTION
Fixes `GetGroupPermissions(..., parents: true)` only including one parent level.